### PR TITLE
Remove deprecated --use-mirrors pip option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 language: java
 python:
 - "2.7"
-install: "sudo pip install Sphinx==1.1.3 --use-mirrors"
+install: "sudo pip install Sphinx==1.1.3"
 jdk:
 - oraclejdk8
 - oraclejdk7


### PR DESCRIPTION
This should fix the broken Travis CI build.