### PR TITLE
Use \r\n as a line separator as well as \n

### DIFF
--- a/src/main/java/org/edumips64/core/Parser.java
+++ b/src/main/java/org/edumips64/core/Parser.java
@@ -227,6 +227,7 @@ public class Parser {
     memoryCount = 0;
     String lastLabel = "";
 
+    code = code.replaceAll("\r\n", "\n");
     for (String line : code.split("\n")) {
       row++;
       logger.info("-- Processing line " + row);

--- a/src/test/java/org/edumips64/core/ParserTest.java
+++ b/src/test/java/org/edumips64/core/ParserTest.java
@@ -59,4 +59,10 @@ public class ParserTest {
   public void FPOverflowNegativeNumberTest() throws Exception {
     ParseDouble("4.95E324");
   }
+
+  /** Regression test for issue #95 */
+  @Test
+  public void CRLFParsingTest() throws Exception {
+    parser.doParsing(".data\r\n.double 8\r\n.code\r\nSYSCALL 0\r\n");
+  }
 }


### PR DESCRIPTION
Fixes #95.

This issue came into existence because we had to get rid of BufferedReader,
since it's not supported by GWT.