### PR TITLE
Correctly emit errors parsing out-of-bounds data

### DIFF
--- a/docs/user/en/src/source-files-format.rst
+++ b/docs/user/en/src/source-files-format.rst
@@ -53,6 +53,9 @@ table.
 Please note that a double word can be introduced either by the `.word`
 directive or by the `.word64` directive.
 
+All the data types are interpreted as signed. This means that integer literals
+in the `.data` section must be between -2^(n-1) and 2^(n-1) - 1 (inclusive).
+
 There is a big difference between declaring a list of data elements
 using a single directive or by using multiple directives of the same type. EduMIPS64
 starts writing from the next 64-bit double word as soon as it finds a datatype identifier,

--- a/docs/user/it/src/source-files-format.rst
+++ b/docs/user/it/src/source-files-format.rst
@@ -57,6 +57,10 @@ tabella.
 Dati di tipo doubleword possono essere introdotti sia dalla direttiva
 `.word` che dalla direttiva `.word64`.
 
+I tipi di dato sono interpretati con segno. Questo significa che tutte le
+costanti intere nella sezione `.data` devono essere compresi tra -2^(n-1) e
+2^(n-1) - 1 (estremi inclusi).
+
 Esiste una differenza sostanziale tra la dichiarazione di una lista di dati 
 utilizzando un'unica direttiva oppure direttive multiple dello stesso tipo.
 EduMIPS64 inizia la scrittura a partire dalla successiva double word a 64 bit non appena 

--- a/src/test/java/org/edumips64/core/ParserTest.java
+++ b/src/test/java/org/edumips64/core/ParserTest.java
@@ -84,4 +84,61 @@ public class ParserTest {
   public void CRLFParsingTest() throws Exception {
     parser.doParsing(".data\r\n.double 8\r\n.code\r\nSYSCALL 0\r\n");
   }
+
+  /** Regression tests for issue #1 */
+  @Test
+  public void NotOutOfBoundsTest() throws Exception {
+    // Test that all the values just before overflow are parsed correctly.
+    ParseData(".byte -128");
+    ParseData(".byte 127");
+    ParseData(".word16 -32768");
+    ParseData(".word16 32767");
+    ParseData(".word32 -2147483648");
+    ParseData(".word32 2147483647");
+
+    ParseData(".word -9223372036854775808");
+    ParseData(".word 9223372036854775807");
+    ParseData(".word64 -9223372036854775808");
+    ParseData(".word64 9223372036854775807");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void OutOfBoundsByteTest() throws Exception {
+    ParseData(".byte 128");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void NegativeOutOfBoundsByteTest() throws Exception {
+    ParseData(".byte -129");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void OutOfBoundsHalfWordTest() throws Exception {
+    ParseData(".word16 32768");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void NegativeOutOfBoundsHalfWordTest() throws Exception {
+    ParseData(".word16 -32769");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void OutOfBoundsWordTest() throws Exception {
+    ParseData(".word32 2147483648");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void NegativeOutOfBoundsWordTest() throws Exception {
+    ParseData(".word32 -2147483649");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void OutOfBoundsDoubleWordTest() throws Exception {
+    ParseData(".word 9223372036854775808");
+  }
+
+  @Test(expected = ParserMultiException.class)
+  public void NegativeOutOfBoundsDoubleWordTest() throws Exception {
+    ParseData(".word -9223372036854775809");
+  }
 }


### PR DESCRIPTION
Fix the bound checking logic, make it emit errors, add unit tests and update
the relative documentation.

Fixes #1.