### PR TITLE
Fix typo in unit tests

### DIFF
--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -421,7 +421,7 @@ public class EndToEndTests extends BaseTest {
   /* Tests for masking synchronous exceptions. Termination cannot be tested here since it's in the CPUGuiThread. */
   @Test(expected = SynchronousException.class)
   public void testDivisionByZeroThrowException() throws Exception {
-    config.putBoolean("syncex-masked", false);
+    config.putBoolean("syncexc-masked", false);
     runMipsTest("div0.s");
   }
 


### PR DESCRIPTION
Fixes #125. The error made the tests depending on the ordering.