### PR TITLE
Change config keys to be typed

### DIFF
--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -230,7 +230,7 @@ public class Main extends JApplet {
 
     configStore = new JavaPrefsConfigStore(ConfigStore.defaults);
     CurrentLocale.setConfig(configStore);
-    jfc = new JFileChooser(new File(configStore.getString("lastdir")));
+    jfc = new JFileChooser(new File(configStore.getString(ConfigKey.LAST_DIR)));
 
     desk = new JDesktopPane();
     Container cp = (f == null) ? getContentPane() : f.getContentPane();
@@ -468,7 +468,7 @@ public class Main extends JApplet {
         String absoluteFilename = new File(file).getAbsolutePath();
         parser.parse(absoluteFilename);
       } catch (ParserMultiWarningException pmwe) {
-        new ErrorDialog(f, pmwe.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean("warnings"));
+        new ErrorDialog(f, pmwe.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean(ConfigKey.WARNINGS));
       } catch (NullPointerException e) {
         log.info("NullPointerException: " + e.toString());
         e.printStackTrace();
@@ -500,7 +500,7 @@ public class Main extends JApplet {
       f.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM") + " - " + nome_file);
     } catch (ParserMultiException ex) {
       log.info("Error opening " + file);
-      new ErrorDialog(f, ex.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean("warnings"));
+      new ErrorDialog(f, ex.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean(ConfigKey.WARNINGS));
       openedFile = null;
       f.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
       resetSimulator(false);
@@ -710,7 +710,7 @@ public class Main extends JApplet {
 
         if (val == JFileChooser.APPROVE_OPTION) {
           String filename = jfc.getSelectedFile().getPath();
-          configStore.putString("lastdir", jfc.getCurrentDirectory().getAbsolutePath());
+          configStore.putString(ConfigKey.LAST_DIR, jfc.getCurrentDirectory().getAbsolutePath());
           addFileToRecentMenu(filename);
 
           resetSimulator(false);
@@ -721,7 +721,7 @@ public class Main extends JApplet {
     });
 
     // Add recently opened files menu items to the recent files submenu.
-    for (String filename : Arrays.asList(configStore.getString("files").split(File.pathSeparator))) {
+    for (String filename : Arrays.asList(configStore.getString(ConfigKey.FILES).split(File.pathSeparator))) {
       if (filename.length() > 0) {
         log.info("Adding '" + filename + "' to recently opened files.");
         addFileToRecentMenu(filename);
@@ -806,7 +806,7 @@ public class Main extends JApplet {
     multi_cycle.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F8, 0));
     multi_cycle.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-        cgt.setSteps(configStore.getInt("n_step"));
+        cgt.setSteps(configStore.getInt(ConfigKey.N_STEPS));
 
         synchronized (cgt) {
           cgt.notify();
@@ -839,7 +839,7 @@ public class Main extends JApplet {
       lang_en = new JCheckBoxMenuItem(
         CurrentLocale.getString("MenuItem.ENGLISH"),
         new ImageIcon(IMGLoader.getImage("en.png")),
-        configStore.getString("language").equals("en"));
+        configStore.getString(ConfigKey.LANGUAGE).equals("en"));
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -850,7 +850,7 @@ public class Main extends JApplet {
       public void actionPerformed(ActionEvent e) {
         lang_en.setState(true);
         lang_it.setState(false);
-        configStore.putString("language", "en");
+        configStore.putString(ConfigKey.LANGUAGE, "en");
         initMenuItems();
         setFrameTitles();
         front.updateLanguageStrings();
@@ -862,7 +862,7 @@ public class Main extends JApplet {
       lang_it = new JCheckBoxMenuItem(
         CurrentLocale.getString("MenuItem.ITALIAN"),
         new ImageIcon(IMGLoader.getImage("it.png")),
-        configStore.getString("language").equals("it"));
+        configStore.getString(ConfigKey.LANGUAGE).equals("it"));
 
       lang.add(lang_it);
     } catch (IOException e) {
@@ -873,7 +873,7 @@ public class Main extends JApplet {
       public void actionPerformed(ActionEvent e) {
         lang_it.setState(true);
         lang_en.setState(false);
-        configStore.putString("language", "it");
+        configStore.putString(ConfigKey.LANGUAGE, "it");
         initMenuItems();
         setFrameTitles();
         front.updateLanguageStrings();
@@ -1067,7 +1067,7 @@ public class Main extends JApplet {
     }
 
     files = files.substring(0, files.length() - 1);
-    configStore.putString("files", files);
+    configStore.putString(ConfigKey.FILES, files);
   }
 
   /** Sets the caption of the menu item, adding, if possible, the mnemonic */

--- a/src/main/java/org/edumips64/core/CPU.java
+++ b/src/main/java/org/edumips64/core/CPU.java
@@ -44,6 +44,7 @@ import org.edumips64.core.is.JumpException;
 import org.edumips64.core.is.RAWException;
 import org.edumips64.core.is.TwosComplementSumException;
 import org.edumips64.core.is.WAWException;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.FPUConfigurator;
 import org.edumips64.utils.IrregularStringOfBitsException;
@@ -575,8 +576,8 @@ public class CPU {
     changeStage(PipeStage.EX);
 
     // Used for exception handling
-    boolean masked = config.getBoolean("syncexc-masked");
-    boolean terminate = config.getBoolean("syncexc-terminate");
+    boolean masked = config.getBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED);
+    boolean terminate = config.getBoolean(ConfigKey.SYNC_EXCEPTIONS_TERMINATE);
 
     // Code of the synchronous exception that happens in EX.
     String syncex = null;
@@ -780,7 +781,7 @@ public class CPU {
   }
 
   public boolean isEnableForwarding() {
-    return config.getBoolean("forwarding");
+    return config.getBoolean(ConfigKey.FORWARDING);
   }
 
   /** Test method that returns a string containing the values of every
@@ -800,19 +801,19 @@ public class CPU {
 
   private void configFPExceptionsAndRM() {
     try {
-      FCSR.setFPExceptions(CPU.FPExceptions.INVALID_OPERATION, config.getBoolean("INVALID_OPERATION"));
-      FCSR.setFPExceptions(CPU.FPExceptions.OVERFLOW, config.getBoolean("OVERFLOW"));
-      FCSR.setFPExceptions(CPU.FPExceptions.UNDERFLOW, config.getBoolean("UNDERFLOW"));
-      FCSR.setFPExceptions(CPU.FPExceptions.DIVIDE_BY_ZERO, config.getBoolean("DIVIDE_BY_ZERO"));
+      FCSR.setFPExceptions(CPU.FPExceptions.INVALID_OPERATION, config.getBoolean(ConfigKey.FP_INVALID_OPERATION));
+      FCSR.setFPExceptions(CPU.FPExceptions.OVERFLOW, config.getBoolean(ConfigKey.FP_OVERFLOW));
+      FCSR.setFPExceptions(CPU.FPExceptions.UNDERFLOW, config.getBoolean(ConfigKey.FP_UNDERFLOW));
+      FCSR.setFPExceptions(CPU.FPExceptions.DIVIDE_BY_ZERO, config.getBoolean(ConfigKey.FP_DIVIDE_BY_ZERO));
 
       //setting the rounding mode
-      if (config.getBoolean("NEAREST")) {
+      if (config.getBoolean(ConfigKey.FP_NEAREST)) {
         FCSR.setFCSRRoundingMode(FPRoundingMode.TO_NEAREST);
-      } else if (config.getBoolean("TOWARDZERO")) {
+      } else if (config.getBoolean(ConfigKey.FP_TOWARDS_ZERO)) {
         FCSR.setFCSRRoundingMode(FPRoundingMode.TOWARD_ZERO);
-      } else if (config.getBoolean("TOWARDS_PLUS_INFINITY")) {
+      } else if (config.getBoolean(ConfigKey.FP_TOWARDS_PLUS_INFINITY)) {
         FCSR.setFCSRRoundingMode(FPRoundingMode.TOWARDS_PLUS_INFINITY);
-      } else if (config.getBoolean("TOWARDS_MINUS_INFINITY")) {
+      } else if (config.getBoolean(ConfigKey.FP_TOWARDS_MINUS_INFINITY)) {
         FCSR.setFCSRRoundingMode(FPRoundingMode.TOWARDS_MINUS_INFINITY);
       }
     } catch (IrregularStringOfBitsException ex) {

--- a/src/main/java/org/edumips64/core/is/InstructionBuilder.java
+++ b/src/main/java/org/edumips64/core/is/InstructionBuilder.java
@@ -4,6 +4,7 @@ import org.edumips64.core.CPU;
 import org.edumips64.core.Dinero;
 import org.edumips64.core.IOManager;
 import org.edumips64.core.Memory;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 
 /** InstructionBuilder should be used to build all the instructions to be run by the CPU. The only exception is
@@ -388,8 +389,8 @@ public class InstructionBuilder {
     }
 
     // Serial number for the instruction being built.
-    int serialNumber = config.getInt("serialNumber");
-    config.putInt("serialNumber", serialNumber + 1);
+    int serialNumber = config.getInt(ConfigKey.SERIAL_NUMBER);
+    config.putInt(ConfigKey.SERIAL_NUMBER, serialNumber + 1);
     instruction.setSerialNumber(serialNumber);
 
     // Inject other dependencies.

--- a/src/main/java/org/edumips64/ui/swing/CPUGUIThread.java
+++ b/src/main/java/org/edumips64/ui/swing/CPUGUIThread.java
@@ -75,10 +75,10 @@ public class CPUGUIThread extends Thread {
    * configuration values from the configuration file.
    */
   public void updateConfigValues() {
-    sleep_interval = config.getInt("sleep_interval");
-    verbose = config.getBoolean("verbose");
-    masked = config.getBoolean("syncexc-masked");
-    terminate = config.getBoolean("syncexc-terminate");
+    sleep_interval = config.getInt(ConfigKey.SLEEP_INTERVAL);
+    verbose = config.getBoolean(ConfigKey.VERBOSE);
+    masked = config.getBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED);
+    terminate = config.getBoolean(ConfigKey.SYNC_EXCEPTIONS_TERMINATE);
     logger.info("Terminate = " + terminate + "; masked = " + masked);
   }
 

--- a/src/main/java/org/edumips64/ui/swing/DineroFrontend.java
+++ b/src/main/java/org/edumips64/ui/swing/DineroFrontend.java
@@ -24,6 +24,7 @@
 package org.edumips64.ui.swing;
 
 import org.edumips64.core.Dinero;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.io.LocalWriterAdapter;
 
@@ -117,7 +118,7 @@ public class DineroFrontend extends JDialog {
     JLabel pathLabel = new JLabel("DineroIV executable path:");
     JLabel paramsLabel = new JLabel("Command line parameters:");
 
-    path = new JTextField(config.getString("dineroIV"));
+    path = new JTextField(config.getString(ConfigKey.DINERO));
     params = new JTextField("-l1-usize 512 -l1-ubsize 64");
 
     path.setPreferredSize(new Dimension(400, 26));
@@ -146,7 +147,7 @@ public class DineroFrontend extends JDialog {
       int val = jfc.showOpenDialog(null);
 
       if (val == JFileChooser.APPROVE_OPTION) {
-        config.putString("dineroIV", jfc.getSelectedFile().getPath());
+        config.putString(ConfigKey.DINERO, jfc.getSelectedFile().getPath());
         path.setText(jfc.getSelectedFile().getPath());
       }
     });

--- a/src/main/java/org/edumips64/ui/swing/GUICode.java
+++ b/src/main/java/org/edumips64/ui/swing/GUICode.java
@@ -244,42 +244,42 @@ public class GUICode extends GUIComponent {
 
       if (rowTable == ifIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("IFColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.IF_COLOR)));
       }
 
       if (rowTable == idIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("IDColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.ID_COLOR)));
       }
 
       if (rowTable == exIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("EXColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.EX_COLOR)));
       }
 
       if (rowTable == memIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("MEMColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.MEM_COLOR)));
       }
 
       if (rowTable == wbIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("WBColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.WB_COLOR)));
       }
 
       if (rowTable == M1Index || rowTable == M2Index || rowTable == M3Index || rowTable == M4Index || rowTable == M5Index || rowTable == M6Index || rowTable == M7Index) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("FPMultiplierColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.FP_MULTIPLIER_COLOR)));
       }
 
       if (rowTable == A1Index || rowTable == A2Index || rowTable == A3Index || rowTable == A4Index) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("FPAdderColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.FP_ADDER_COLOR)));
       }
 
       if (rowTable == DIVIndex) {
         label.setOpaque(true);
-        label.setBackground(new Color(config.getInt("FPDividerColor")));
+        label.setBackground(new Color(config.getInt(ConfigKey.FP_DIVIDER_COLOR)));
       }
 
       return label;

--- a/src/main/java/org/edumips64/ui/swing/GUIConfig.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIConfig.java
@@ -22,6 +22,7 @@
  */
 package org.edumips64.ui.swing;
 
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.ConfigStoreTypeException;
 import org.edumips64.utils.CurrentLocale;
@@ -67,7 +68,7 @@ public class GUIConfig extends JDialog {
 
   // Local cache of the configuration values that will need to be applied to
   // the configuration backend.
-  private Map<String, Object> cache;
+  private Map<ConfigKey, Object> cache;
   private ConfigStore config;
 
   public GUIConfig(final JFrame owner, ConfigStore config) {
@@ -123,8 +124,8 @@ public class GUIConfig extends JDialog {
     panel.setAlignmentY(JPanel.TOP_ALIGNMENT);
     int row = 2;
 
-    addRow(panel, row++, "forwarding", new JCheckBox());
-    addRow(panel, row++, "n_step", new JNumberField());
+    addRow(panel, row++, ConfigKey.FORWARDING, new JCheckBox());
+    addRow(panel, row++, ConfigKey.N_STEPS, new JNumberField());
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);
@@ -145,11 +146,11 @@ public class GUIConfig extends JDialog {
     panel.setAlignmentY(JPanel.TOP_ALIGNMENT);
     int row = 2;
 
-    addRow(panel, row++, "warnings", new JCheckBox());
-    addRow(panel, row++, "verbose", new JCheckBox());
-    addRow(panel, row++, "sleep_interval", new JNumberField());
-    addRow(panel, row++, "syncexc-masked", new JCheckBox());
-    addRow(panel, row++, "syncexc-terminate", new JCheckBox());
+    addRow(panel, row++, ConfigKey.WARNINGS, new JCheckBox());
+    addRow(panel, row++, ConfigKey.VERBOSE, new JCheckBox());
+    addRow(panel, row++, ConfigKey.SLEEP_INTERVAL, new JNumberField());
+    addRow(panel, row++, ConfigKey.SYNC_EXCEPTIONS_MASKED, new JCheckBox());
+    addRow(panel, row++, ConfigKey.SYNC_EXCEPTIONS_TERMINATE, new JCheckBox());
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);
@@ -171,10 +172,10 @@ public class GUIConfig extends JDialog {
     panel.setAlignmentY(JPanel.TOP_ALIGNMENT);
     int row = 2;
 
-    addRow(panel, row++, "INVALID_OPERATION", new JCheckBox());
-    addRow(panel, row++, "OVERFLOW", new JCheckBox());
-    addRow(panel, row++, "UNDERFLOW", new JCheckBox());
-    addRow(panel, row++, "DIVIDE_BY_ZERO", new JCheckBox());
+    addRow(panel, row++, ConfigKey.FP_INVALID_OPERATION, new JCheckBox());
+    addRow(panel, row++, ConfigKey.FP_OVERFLOW, new JCheckBox());
+    addRow(panel, row++, ConfigKey.FP_UNDERFLOW, new JCheckBox());
+    addRow(panel, row++, ConfigKey.FP_DIVIDE_BY_ZERO, new JCheckBox());
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);
@@ -207,10 +208,10 @@ public class GUIConfig extends JDialog {
     panel.setAlignmentY(JPanel.TOP_ALIGNMENT);
     int row = 2;
 
-    addRow(panel, row++, "NEAREST", rdoNearest);
-    addRow(panel, row++, "TOWARDZERO", rdoTowardZero);
-    addRow(panel, row++, "TOWARDS_PLUS_INFINITY", rdoTowardsPlusInfinity);
-    addRow(panel, row++, "TOWARDS_MINUS_INFINITY", rdoTowardsMinusInfinity);
+    addRow(panel, row++, ConfigKey.FP_NEAREST, rdoNearest);
+    addRow(panel, row++, ConfigKey.FP_TOWARDS_ZERO, rdoTowardZero);
+    addRow(panel, row++, ConfigKey.FP_TOWARDS_PLUS_INFINITY, rdoTowardsPlusInfinity);
+    addRow(panel, row++, ConfigKey.FP_TOWARDS_MINUS_INFINITY, rdoTowardsMinusInfinity);
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);
@@ -232,16 +233,16 @@ public class GUIConfig extends JDialog {
     panel.setAlignmentY(JPanel.TOP_ALIGNMENT);
     int row = 2;
 
-    addRow(panel, row++, "IFColor", new JButton());
-    addRow(panel, row++, "IDColor", new JButton());
-    addRow(panel, row++, "EXColor", new JButton());
-    addRow(panel, row++, "MEMColor", new JButton());
-    addRow(panel, row++, "WBColor", new JButton());
-    addRow(panel, row++, "FPAdderColor", new JButton());
-    addRow(panel, row++, "FPMultiplierColor", new JButton());
-    addRow(panel, row++, "FPDividerColor", new JButton());
-    addRow(panel, row++, "LONGDOUBLEVIEW", new JCheckBox());
-    addRow(panel, row++, "show_aliases", new JCheckBox());
+    addRow(panel, row++, ConfigKey.IF_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.ID_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.EX_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.MEM_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.WB_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.FP_ADDER_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.FP_MULTIPLIER_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.FP_DIVIDER_COLOR, new JButton());
+    addRow(panel, row++, ConfigKey.FP_LONG_DOUBLE_VIEW, new JCheckBox());
+    addRow(panel, row++, ConfigKey.SHOW_ALIASES, new JCheckBox());
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);
@@ -250,9 +251,9 @@ public class GUIConfig extends JDialog {
 
   // Monster function that adds a given row (label + control) to a given
   // JPanel, and sets its behaviour according to the type of control.
-  private void addRow(JPanel panel, final int row, final String key, final JComponent comp) {
-    String title = CurrentLocale.getString("Config." + key.toUpperCase());
-    String tip = CurrentLocale.getString("Config." + key.toUpperCase() + ".tip");
+  private void addRow(JPanel panel, final int row, final ConfigKey key, final JComponent comp) {
+    String title = CurrentLocale.getString("Config." + String.valueOf(key).toUpperCase());
+    String tip = CurrentLocale.getString("Config." + String.valueOf(key).toUpperCase() + ".tip");
     //Setting title
     JLabel label = new JLabel(title);
     label.setHorizontalAlignment(JLabel.RIGHT);
@@ -285,16 +286,16 @@ public class GUIConfig extends JDialog {
       // one and this code is tailored for it.
       rbut.setAction(new AbstractAction() {
         public void actionPerformed(ActionEvent e) {
-          LinkedList<String> keys = new LinkedList<>();
-          keys.add("NEAREST");
-          keys.add("TOWARDZERO");
-          keys.add("TOWARDS_PLUS_INFINITY");
-          keys.add("TOWARDS_MINUS_INFINITY");
+          LinkedList<ConfigKey> keys = new LinkedList<>();
+          keys.add(ConfigKey.FP_NEAREST);
+          keys.add(ConfigKey.FP_TOWARDS_ZERO);
+          keys.add(ConfigKey.FP_TOWARDS_PLUS_INFINITY);
+          keys.add(ConfigKey.FP_TOWARDS_MINUS_INFINITY);
 
           cache.put(key, true);
           keys.remove(key);
 
-          for (String k : keys) {
+          for (ConfigKey k : keys) {
             cache.put(k, false);
           }
         }
@@ -346,7 +347,7 @@ public class GUIConfig extends JDialog {
       button.addActionListener(e -> {
         Color color = JColorChooser.showDialog(
                         GUIConfig.this,
-                        CurrentLocale.getString("Config." + key.toUpperCase()),
+                        CurrentLocale.getString("Config." + String.valueOf(key).toUpperCase()),
                         button.getBackground());
 
         if (color != null) {

--- a/src/main/java/org/edumips64/ui/swing/GUICycles.java
+++ b/src/main/java/org/edumips64/ui/swing/GUICycles.java
@@ -28,6 +28,7 @@ import org.edumips64.core.CPU;
 import org.edumips64.core.Memory;
 import org.edumips64.ui.common.CycleBuilder;
 import org.edumips64.ui.common.CycleElement;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 
 import java.awt.*;
@@ -155,30 +156,30 @@ public class GUICycles extends GUIComponent {
 
     private Color getColorByState(String st, String pre) {
       if (st.equals("IF")) {
-        return new Color(config.getInt("IFColor"));
+        return new Color(config.getInt(ConfigKey.IF_COLOR));
       } else if (st.equals("ID")) {
-        return new Color(config.getInt("IDColor"));
+        return new Color(config.getInt(ConfigKey.ID_COLOR));
       } else if (st.equals("EX")) {
-        return new Color(config.getInt("EXColor"));
+        return new Color(config.getInt(ConfigKey.EX_COLOR));
       } else if (st.equals("MEM")) {
-        return new Color(config.getInt("MEMColor"));
+        return new Color(config.getInt(ConfigKey.MEM_COLOR));
       } else if (st.equals("WB")) {
-        return new Color(config.getInt("WBColor"));
+        return new Color(config.getInt(ConfigKey.WB_COLOR));
       } else if (st.equals("Str")) {
-        return new Color(config.getInt("EXColor"));
+        return new Color(config.getInt(ConfigKey.EX_COLOR));
       } else if (st.equals("A1") || st.equals("A2") || st.equals("A3") || st.equals("A4") || st.equals("StAdd")) {
-        return new Color(config.getInt("FPAdderColor"));
+        return new Color(config.getInt(ConfigKey.FP_ADDER_COLOR));
       } else if (st.equals("M1") || st.equals("M2") || st.equals("M3") || st.equals("M4") || st.equals("M5") || st.equals("M6") || st.equals("M7") || st.equals("StMul")) {
-        return new Color(config.getInt("FPMultiplierColor"));
+        return new Color(config.getInt(ConfigKey.FP_MULTIPLIER_COLOR));
       } else if (st.matches("D[0-2][0-9]") || st.matches("DIV")) {
-        return new Color(config.getInt("FPDividerColor"));
+        return new Color(config.getInt(ConfigKey.FP_DIVIDER_COLOR));
       } else if (st.equals("RAW")) {
-        return new Color(config.getInt("IDColor"));
+        return new Color(config.getInt(ConfigKey.ID_COLOR));
       } else if (st.equals("WAW") || st.equals("StDiv") || st.equals("StEx") || st.equals("StFun")) {
-        return new Color(config.getInt("IDColor"));
+        return new Color(config.getInt(ConfigKey.ID_COLOR));
       } else if (st.equals(" ")) {
         if (pre.equals("IF")) {
-          return new Color(config.getInt("IFColor"));
+          return new Color(config.getInt(ConfigKey.IF_COLOR));
         }
       }
       return null;

--- a/src/main/java/org/edumips64/ui/swing/GUIData.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIData.java
@@ -127,7 +127,7 @@ public class GUIData extends GUIComponent {
                            " " + tableModel.getValueAt(theTable.getSelectedRow(), 0) + " : ";
 
             //if the current memory cell visualization is long
-            if (config.getBoolean("LONGDOUBLEVIEW")) {
+            if (config.getBoolean(ConfigKey.FP_LONG_DOUBLE_VIEW)) {
               value += Converter.hexToLong("0X" + tableModel.getValueAt(theTable.getSelectedRow(), 1));
             } else { //the current memory cell visualization in the status bar is double, we build a temp. bitset in order to read the double value
               BitSet64FP bs = new BitSet64FP();

--- a/src/main/java/org/edumips64/ui/swing/GUIPipeline.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIPipeline.java
@@ -22,6 +22,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 package org.edumips64.ui.swing;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.core.*;
 import org.edumips64.core.is.*;
@@ -200,42 +201,42 @@ class GUIPipeline extends GUIComponent {
       Instruction i = pipeline.get(CPU.PipeStage.IF);
 
       if ((i != null) && ((i.getName() != null)) && !i.isBubble()) {
-        g.setColor(new Color(config.getInt("IFColor")));
+        g.setColor(new Color(config.getInt(ConfigKey.IF_COLOR)));
         g.fillRect(largh / 20, (alt / 2) - (alt / 12), largh / 10, alt / 6);
       }
 
       i = pipeline.get(CPU.PipeStage.ID);
 
       if ((i != null) && ((i.getName() != null)) && !i.isBubble()) {
-        g.setColor(new Color(config.getInt("IDColor")));
+        g.setColor(new Color(config.getInt(ConfigKey.ID_COLOR)));
         g.fillRect(largh * 4 / 20, (alt / 2) - (alt / 12), largh / 10, alt / 6);
       }
 
       i = pipeline.get(CPU.PipeStage.EX);
 
       if ((i != null) && ((i.getName() != null)) && !i.isBubble()) {
-        g.setColor(new Color(config.getInt("EXColor")));
+        g.setColor(new Color(config.getInt(ConfigKey.EX_COLOR)));
         g.fillRect(largh * 9 / 20, (alt / 2) - (alt * 5 / 12), largh / 10, alt / 6);
       }
 
       i = pipeline.get(CPU.PipeStage.MEM);
 
       if ((i != null) && ((i.getName() != null)) && !i.isBubble()) {
-        g.setColor(new Color(config.getInt("MEMColor")));
+        g.setColor(new Color(config.getInt(ConfigKey.MEM_COLOR)));
         g.fillRect(largh * 14 / 20, (alt / 2) - (alt / 12), largh / 10, alt / 6);
       }
 
       i = pipeline.get(CPU.PipeStage.WB);
 
       if ((i != null) && ((i.getName() != null)) && !i.isBubble()) {
-        g.setColor(new Color(config.getInt("WBColor")));
+        g.setColor(new Color(config.getInt(ConfigKey.WB_COLOR)));
         g.fillRect(largh * 17 / 20, (alt / 2) - (alt / 12), largh / 10, alt / 6);
       }
 
 
       //filling FPU elements
       //ADDER
-      g.setColor(new Color(config.getInt("FPAdderColor")));
+      g.setColor(new Color(config.getInt(ConfigKey.FP_ADDER_COLOR)));
       spiazzAdd = (largh * 20 / 60) / numAdder;
       int j;
 
@@ -260,7 +261,7 @@ class GUIPipeline extends GUIComponent {
       }
 
 //MULTIPLIER
-      g.setColor(new Color(config.getInt("FPMultiplierColor")));
+      g.setColor(new Color(config.getInt(ConfigKey.FP_MULTIPLIER_COLOR)));
       spiazzMul = (largh * 20 / 60) / numMultiplier;
 
       if (cpu.isFuncUnitFilled("MULTIPLIER", 1)) {
@@ -299,7 +300,7 @@ class GUIPipeline extends GUIComponent {
       }
 
       //DIVIDER
-      g.setColor(new Color(config.getInt("FPDividerColor")));
+      g.setColor(new Color(config.getInt(ConfigKey.FP_DIVIDER_COLOR)));
 
       if (cpu.isFuncUnitFilled("DIVIDER", 0)) {
         g.fillRect(largh * 8 / 20, (alt / 2) + (alt * 3 / 12), largh * 2 / 10, alt / 6);

--- a/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
@@ -27,10 +27,7 @@ import org.edumips64.core.CPU;
 import org.edumips64.core.Memory;
 import org.edumips64.core.Register;
 import org.edumips64.core.RegisterFP;
-import org.edumips64.utils.ConfigStore;
-import org.edumips64.utils.Converter;
-import org.edumips64.utils.CurrentLocale;
-import org.edumips64.utils.IrregularStringOfHexException;
+import org.edumips64.utils.*;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -201,7 +198,7 @@ class GUIRegisters extends GUIComponent {
     }
 
     String fillFirstColumn(int i) {
-      if (config.getBoolean("show_aliases")) {
+      if (config.getBoolean(ConfigKey.SHOW_ALIASES)) {
         return registerToAlias(" " + i) + "=";
       } else {
         return "R" + i + " =";

--- a/src/main/java/org/edumips64/utils/ConfigKey.java
+++ b/src/main/java/org/edumips64/utils/ConfigKey.java
@@ -1,0 +1,53 @@
+package org.edumips64.utils;
+
+/** An enum representing a key in the configuration database. Used to provide
+ * compile-type checking of keys.
+ *  
+ * The actual string values should not be changed, because the keys will
+ * already have been used by previous versions of the simulator, therefore
+ * such a change will result in loss of the saved value.
+ */
+public enum ConfigKey {
+    LANGUAGE("language"),
+    FILES("files"),
+    LAST_DIR("lastdir"),
+    DINERO("dineroIV"),
+    SERIAL_NUMBER("serialNumber"),
+    IF_COLOR("IFColor"),
+    ID_COLOR("IDColor"),
+    EX_COLOR("EXColor"),
+    MEM_COLOR("MEMColor"),
+    FP_ADDER_COLOR("FPAdderColor"),
+    FP_MULTIPLIER_COLOR("FPMultiplierColor"),
+    FP_DIVIDER_COLOR("FPDividerColor"),
+    WB_COLOR("WBColor"),
+    RAW_COLOR("RAWColor"),
+    SAME_IF_COLOR("SAMEIFColor"),
+    FORWARDING("forwarding"),
+    WARNINGS("warnings"),
+    VERBOSE("verbose"),
+    SYNC_EXCEPTIONS_MASKED("syncexc-masked"),
+    SYNC_EXCEPTIONS_TERMINATE("syncexc-terminate"),
+    N_STEPS("n_step"),
+    SLEEP_INTERVAL("sleep_interval"),
+    SHOW_ALIASES("show_aliases"),
+    FP_INVALID_OPERATION("INVALID_OPERATION"),
+    FP_OVERFLOW("OVERFLOW"),
+    FP_UNDERFLOW("UNDERFLOW"),
+    FP_DIVIDE_BY_ZERO("DIVIDE_BY_ZERO"),
+    FP_NEAREST("NEAREST"),
+    FP_TOWARDS_ZERO("TOWARDZERO"),
+    FP_TOWARDS_PLUS_INFINITY("TOWARDS_PLUS_INFINITY"),
+    FP_TOWARDS_MINUS_INFINITY("TOWARDS_MINUS_INFINITY"),
+    FP_LONG_DOUBLE_VIEW("LONGDOUBLEVIEW");
+    
+    private final String text;
+    
+    private ConfigKey(String text) {
+        this.text = text;
+    }
+    
+    public String toString() {
+        return text;
+    }
+}

--- a/src/main/java/org/edumips64/utils/ConfigStore.java
+++ b/src/main/java/org/edumips64/utils/ConfigStore.java
@@ -32,75 +32,75 @@ import java.util.logging.Logger;
  * storage object by calling the getConfig method of ConfigManager.
  * */
 public abstract class ConfigStore {
-  public static Map<String, Object> defaults;
+  public static Map<ConfigKey, Object> defaults;
   static {
     ConfigStore.defaults = new HashMap<>();
 
     // Global parameters.
-    ConfigStore.defaults.put("language", "en");
-    ConfigStore.defaults.put("files", "");
+    ConfigStore.defaults.put(ConfigKey.LANGUAGE, "en");
+    ConfigStore.defaults.put(ConfigKey.FILES, "");
     // TODO(andrea): this will create problems in the applet, and needs to be
     // encapsulated in some way.
-    ConfigStore.defaults.put("lastdir", System.getProperty("user.dir", ""));
-    ConfigStore.defaults.put("dineroIV", "dineroIV");
-    ConfigStore.defaults.put("serialNumber", 0);
+    ConfigStore.defaults.put(ConfigKey.LAST_DIR, System.getProperty("user.dir", ""));
+    ConfigStore.defaults.put(ConfigKey.DINERO, "dineroIV");
+    ConfigStore.defaults.put(ConfigKey.SERIAL_NUMBER, 0);
 
     // Colors.
-    ConfigStore.defaults.put("IFColor", -256);                // Color.yellow.getRGB())
-    ConfigStore.defaults.put("IDColor", -16746256);           // Color(0, 120, 240).getRGB());
-    ConfigStore.defaults.put("EXColor", -65536);              // Color.red.getRGB());
-    ConfigStore.defaults.put("MEMColor", -16711936);          // Color.green.getRGB());
-    ConfigStore.defaults.put("FPAdderColor", -16744448);      // Color(0, 128, 0).getRGB());
-    ConfigStore.defaults.put("FPMultiplierColor",-16744320);  // Color(0, 128, 128).getRGB());
-    ConfigStore.defaults.put("FPDividerColor", -8355840);     // Color(128, 128, 0).getRGB());
-    ConfigStore.defaults.put("WBColor", -5111630);            // Color.magenta.darker().getRGB());
-    ConfigStore.defaults.put("RAWColor", -16776961);          // Color.blue.brighter().getRGB());
-    ConfigStore.defaults.put("SAMEIFColor", -6908236);        // Color(150, 150, 180).getRGB());
+    ConfigStore.defaults.put(ConfigKey.IF_COLOR, -256);                // Color.yellow.getRGB())
+    ConfigStore.defaults.put(ConfigKey.ID_COLOR, -16746256);           // Color(0, 120, 240).getRGB());
+    ConfigStore.defaults.put(ConfigKey.EX_COLOR, -65536);              // Color.red.getRGB());
+    ConfigStore.defaults.put(ConfigKey.MEM_COLOR, -16711936);          // Color.green.getRGB());
+    ConfigStore.defaults.put(ConfigKey.FP_ADDER_COLOR, -16744448);      // Color(0, 128, 0).getRGB());
+    ConfigStore.defaults.put(ConfigKey.FP_MULTIPLIER_COLOR,-16744320);  // Color(0, 128, 128).getRGB());
+    ConfigStore.defaults.put(ConfigKey.FP_DIVIDER_COLOR, -8355840);     // Color(128, 128, 0).getRGB());
+    ConfigStore.defaults.put(ConfigKey.WB_COLOR, -5111630);            // Color.magenta.darker().getRGB());
+    ConfigStore.defaults.put(ConfigKey.RAW_COLOR, -16776961);          // Color.blue.brighter().getRGB());
+    ConfigStore.defaults.put(ConfigKey.SAME_IF_COLOR, -6908236);        // Color(150, 150, 180).getRGB());
 
     // Simulation parameters.
-    ConfigStore.defaults.put("forwarding", false);
-    ConfigStore.defaults.put("warnings", false);
-    ConfigStore.defaults.put("verbose", true);
-    ConfigStore.defaults.put("syncexc-masked", false);
-    ConfigStore.defaults.put("syncexc-terminate", false);
-    ConfigStore.defaults.put("n_step", 4);
-    ConfigStore.defaults.put("sleep_interval", 10);
-    ConfigStore.defaults.put("show_aliases", false);
+    ConfigStore.defaults.put(ConfigKey.FORWARDING, false);
+    ConfigStore.defaults.put(ConfigKey.WARNINGS, false);
+    ConfigStore.defaults.put(ConfigKey.VERBOSE, true);
+    ConfigStore.defaults.put(ConfigKey.SYNC_EXCEPTIONS_MASKED, false);
+    ConfigStore.defaults.put(ConfigKey.SYNC_EXCEPTIONS_TERMINATE, false);
+    ConfigStore.defaults.put(ConfigKey.N_STEPS, 4);
+    ConfigStore.defaults.put(ConfigKey.SLEEP_INTERVAL, 10);
+    ConfigStore.defaults.put(ConfigKey.SHOW_ALIASES, false);
 
     // FPU exceptions defaults.
-    ConfigStore.defaults.put("INVALID_OPERATION", true);
-    ConfigStore.defaults.put("OVERFLOW", true);
-    ConfigStore.defaults.put("UNDERFLOW", true);
-    ConfigStore.defaults.put("DIVIDE_BY_ZERO", true);
+    ConfigStore.defaults.put(ConfigKey.FP_INVALID_OPERATION, true);
+    ConfigStore.defaults.put(ConfigKey.FP_OVERFLOW, true);
+    ConfigStore.defaults.put(ConfigKey.FP_UNDERFLOW, true);
+    ConfigStore.defaults.put(ConfigKey.FP_DIVIDE_BY_ZERO, true);
 
     // FPU Rounding mode defaults.
-    ConfigStore.defaults.put("NEAREST", false);
-    ConfigStore.defaults.put("TOWARDZERO", true);
-    ConfigStore.defaults.put("TOWARDS_PLUS_INFINITY", false);
-    ConfigStore.defaults.put("TOWARDS_MINUS_INFINITY", false);
+    ConfigStore.defaults.put(ConfigKey.FP_NEAREST, false);
+    ConfigStore.defaults.put(ConfigKey.FP_TOWARDS_ZERO, true);
+    ConfigStore.defaults.put(ConfigKey.FP_TOWARDS_PLUS_INFINITY, false);
+    ConfigStore.defaults.put(ConfigKey.FP_TOWARDS_MINUS_INFINITY, false);
 
     // How to show memory cells containing floating point values.
-    ConfigStore.defaults.put("LONGDOUBLEVIEW", true);  // long=true  double=false
+    ConfigStore.defaults.put(ConfigKey.FP_LONG_DOUBLE_VIEW, true);  // long=true  double=false
   }
 
   // The interface exposes getter and setter methods for all the supported
   // types (String, int, boolean, Color). Color is serialized as an int.
-  public abstract void putString(String key, String value);
-  public abstract String getString(String key);
+  public abstract void putString(ConfigKey key, String value);
+  public abstract String getString(ConfigKey key);
 
-  public abstract void putInt(String key, int value);
-  public abstract int getInt(String key);
+  public abstract void putInt(ConfigKey key, int value);
+  public abstract int getInt(ConfigKey key);
 
-  public abstract void putBoolean(String key, boolean value);
-  public abstract boolean getBoolean(String key);
+  public abstract void putBoolean(ConfigKey key, boolean value);
+  public abstract boolean getBoolean(ConfigKey key);
 
   protected static final Logger logger = Logger.getLogger(ConfigStore.class.getName());
 
   // Generic utility function to populate a ConfigStore object from a set of
   // <String, Object> pairs.
-  public void mergeFromGenericMap(Map<String, Object> values) throws ConfigStoreTypeException {
-    for (Map.Entry<String, Object> item : values.entrySet()) {
-      String key = item.getKey();
+  public void mergeFromGenericMap(Map<ConfigKey, Object> values) throws ConfigStoreTypeException {
+    for (Map.Entry<ConfigKey, Object> item : values.entrySet()) {
+      ConfigKey key = item.getKey();
       Object value = item.getValue();
 
       if (value instanceof String) {

--- a/src/main/java/org/edumips64/utils/CurrentLocale.java
+++ b/src/main/java/org/edumips64/utils/CurrentLocale.java
@@ -220,7 +220,7 @@ public class CurrentLocale {
     en.put("ErrorDialog.DESCRIPTION", "Description");
     en.put("ErrorDialog.MSG0", "Code contains");
     en.put("ErrorDialog.MSG1", "errors and");
-    en.put("ErrorDialog.MSG2", "warnings");
+    en.put("ErrorDialog.MSG2", String.valueOf(ConfigKey.WARNINGS));
     en.put("ReportDialog.MSG", "EduMIPS64 Fatal error! Please help the developers, by opening a new issue on GitHub (https://github.com/lupino3/edumips64/issues/new) with the following text, or by sending it via email to bugs@edumips.org");
     en.put("ReportDialog.BUTTON", "Close");
     en.put("DIVZERO.Message", "Division by zero");
@@ -484,7 +484,7 @@ public class CurrentLocale {
   public static String getString(String key) {
     String lang_name = "en";
     if (config != null) {
-      lang_name = config.getString("language");
+      lang_name = config.getString(ConfigKey.LANGUAGE);
     }
 
     try {

--- a/src/main/java/org/edumips64/utils/InMemoryConfigStore.java
+++ b/src/main/java/org/edumips64/utils/InMemoryConfigStore.java
@@ -7,19 +7,21 @@ import java.util.logging.Logger;
 /** ConfigStore implementation based on in-memory storage. */
 public class InMemoryConfigStore extends ConfigStore {
   private static final Logger logger = Logger.getLogger(InMemoryConfigStore.class.getName());
-  private Map<String, Object> data;
-  private Map<String, Object> defaults;
+  private Map<ConfigKey, Object> data;
+  private Map<ConfigKey, Object> defaults;
 
-  public InMemoryConfigStore(Map<String, Object> defaults) {
+  public InMemoryConfigStore(Map<ConfigKey, Object> defaults) {
     this.defaults = defaults;
-    data = new HashMap<String, Object>();
+    data = new HashMap<>();
   }
 
-  public void putString(String key, String value) {
+  @Override
+  public void putString(ConfigKey key, String value) {
     data.put(key, value);
   }
 
-  public String getString(String key) {
+  @Override
+  public String getString(ConfigKey key) {
     if (data.containsKey(key)) {
       return (String) data.get(key);
     }
@@ -35,11 +37,13 @@ public class InMemoryConfigStore extends ConfigStore {
     return default_value;
   }
 
-  public void putInt(String key, int value) {
+  @Override
+  public void putInt(ConfigKey key, int value) {
     data.put(key, value);
   }
 
-  public int getInt(String key) {
+  @Override
+  public int getInt(ConfigKey key) {
     if (data.containsKey(key)) {
       return (Integer) data.get(key);
     }
@@ -55,11 +59,13 @@ public class InMemoryConfigStore extends ConfigStore {
     return default_value;
   }
 
-  public void putBoolean(String key, boolean value) {
+  @Override
+  public void putBoolean(ConfigKey key, boolean value) {
     data.put(key, value);
   }
 
-  public boolean getBoolean(String key) {
+  @Override
+  public boolean getBoolean(ConfigKey key) {
     if (data.containsKey(key)) {
       return (Boolean) data.get(key);
     }

--- a/src/main/java/org/edumips64/utils/JavaPrefsConfigStore.java
+++ b/src/main/java/org/edumips64/utils/JavaPrefsConfigStore.java
@@ -8,18 +8,20 @@ import java.util.prefs.Preferences;
 public class JavaPrefsConfigStore extends ConfigStore {
   private static final Logger logger = Logger.getLogger(JavaPrefsConfigStore.class.getName());
   private Preferences prefs;
-  private Map<String, Object> defaults;
+  private Map<ConfigKey, Object> defaults;
 
-  public JavaPrefsConfigStore(Map<String, Object> defaults) {
+  public JavaPrefsConfigStore(Map<ConfigKey, Object> defaults) {
     prefs = Preferences.userRoot().node("edumips64.config");
     this.defaults = defaults;
   }
 
-  public void putString(String key, String value) {
-    prefs.put(key, value);
+  @Override
+  public void putString(ConfigKey key, String value) {
+    prefs.put(String.valueOf(key), value);
   }
 
-  public String getString(String key) {
+  @Override
+  public String getString(ConfigKey key) {
     String default_value = "";
 
     if (defaults.containsKey(key)) {
@@ -28,14 +30,16 @@ public class JavaPrefsConfigStore extends ConfigStore {
       logger.warning("No default value for string configuration key " + key + ", using empty string.");
     }
 
-    return prefs.get(key, default_value);
+    return prefs.get(String.valueOf(key), default_value);
   }
 
-  public void putInt(String key, int value) {
-    prefs.putInt(key, value);
+  @Override
+  public void putInt(ConfigKey key, int value) {
+    prefs.putInt(String.valueOf(key), value);
   }
 
-  public int getInt(String key) {
+  @Override
+  public int getInt(ConfigKey key) {
     int default_value = 0;
 
     if (defaults.containsKey(key)) {
@@ -44,14 +48,16 @@ public class JavaPrefsConfigStore extends ConfigStore {
       logger.warning("No default value for integer configuration key " + key + ", using 0.");
     }
 
-    return prefs.getInt(key, default_value);
+    return prefs.getInt(String.valueOf(key), default_value);
   }
 
-  public void putBoolean(String key, boolean value) {
-    prefs.putBoolean(key, value);
+  @Override
+  public void putBoolean(ConfigKey key, boolean value) {
+    prefs.putBoolean(String.valueOf(key), value);
   }
 
-  public boolean getBoolean(String key) {
+  @Override
+  public boolean getBoolean(ConfigKey key) {
     boolean default_value = false;
 
     if (defaults.containsKey(key)) {
@@ -60,6 +66,6 @@ public class JavaPrefsConfigStore extends ConfigStore {
       logger.warning("No default value for boolean configuration key " + key + ", using false.");
     }
 
-    return prefs.getBoolean(key, default_value);
+    return prefs.getBoolean(String.valueOf(key), default_value);
   }
 }

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -28,6 +28,7 @@ package org.edumips64;
 import org.edumips64.core.*;
 import org.edumips64.core.is.*;
 import org.edumips64.ui.common.CycleBuilder;
+import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.IrregularStringOfBitsException;
 import org.edumips64.utils.io.FileUtils;
 import org.edumips64.utils.io.LocalFileUtils;
@@ -106,18 +107,18 @@ public class EndToEndTests extends BaseTest {
 
     // Constructor, initializes the values from the Config store.
     public FPUExceptionsConfig() {
-      invalidOperation = config.getBoolean("INVALID_OPERATION");
-      overflow = config.getBoolean("OVERFLOW");
-      underflow = config.getBoolean("UNDERFLOW");
-      divideByZero = config.getBoolean("DIVIDE_BY_ZERO");
+      invalidOperation = config.getBoolean(ConfigKey.FP_INVALID_OPERATION);
+      overflow = config.getBoolean(ConfigKey.FP_OVERFLOW);
+      underflow = config.getBoolean(ConfigKey.FP_UNDERFLOW);
+      divideByZero = config.getBoolean(ConfigKey.FP_DIVIDE_BY_ZERO);
     }
 
     // Restore values to the config Store.
     void restore() {
-      config.putBoolean("INVALID_OPERATION", invalidOperation);
-      config.putBoolean("OVERFLOW", overflow);
-      config.putBoolean("UNDERFLOW", underflow);
-      config.putBoolean("DIVIDE_BY_ZERO", divideByZero);
+      config.putBoolean(ConfigKey.FP_INVALID_OPERATION, invalidOperation);
+      config.putBoolean(ConfigKey.FP_OVERFLOW, overflow);
+      config.putBoolean(ConfigKey.FP_UNDERFLOW, underflow);
+      config.putBoolean(ConfigKey.FP_DIVIDE_BY_ZERO, divideByZero);
     }
   }
 
@@ -136,7 +137,7 @@ public class EndToEndTests extends BaseTest {
     iom.setStdOutput(stdOut);
     InstructionBuilder instructionBuilder = new InstructionBuilder(memory, iom, cpu, dinero, config);
     parser  = new Parser(lfu, symTab, memory, instructionBuilder);
-    config.putBoolean("forwarding", true);
+    config.putBoolean(ConfigKey.FORWARDING, true);
     fec = new FPUExceptionsConfig();
   }
 
@@ -204,16 +205,16 @@ public class EndToEndTests extends BaseTest {
    * corresponding CpuTestStatus object.
    */
   private Map<ForwardingStatus, CpuTestStatus> runMipsTestWithAndWithoutForwarding(String testPath) throws Exception {
-    boolean forwardingStatus = config.getBoolean("forwarding");
+    boolean forwardingStatus = config.getBoolean(ConfigKey.FORWARDING);
     Map<ForwardingStatus, CpuTestStatus> statuses = new HashMap<>();
 
-    config.putBoolean("forwarding", true);
+    config.putBoolean(ConfigKey.FORWARDING, true);
     statuses.put(ForwardingStatus.ENABLED, runMipsTest(testPath));
 
-    config.putBoolean("forwarding", false);
+    config.putBoolean(ConfigKey.FORWARDING, false);
     statuses.put(ForwardingStatus.DISABLED, runMipsTest(testPath));
 
-    config.putBoolean("forwarding", forwardingStatus);
+    config.putBoolean(ConfigKey.FORWARDING, forwardingStatus);
     return statuses;
   }
 
@@ -375,10 +376,10 @@ public class EndToEndTests extends BaseTest {
   @Test
   public void testFPUMul() throws Exception {
     // This test contains code that raises exceptions, let's disable them.
-    config.putBoolean("INVALID_OPERATION", false);
-    config.putBoolean("OVERFLOW", false);
-    config.putBoolean("UNDERFLOW", false);
-    config.putBoolean("DIVIDE_BY_ZERO", false);
+    config.putBoolean(ConfigKey.FP_INVALID_OPERATION, false);
+    config.putBoolean(ConfigKey.FP_OVERFLOW, false);
+    config.putBoolean(ConfigKey.FP_UNDERFLOW, false);
+    config.putBoolean(ConfigKey.FP_DIVIDE_BY_ZERO, false);
     Map<ForwardingStatus, CpuTestStatus> statuses = runMipsTestWithAndWithoutForwarding("fpu-mul.s");
 
     // Same behaviour with and without forwarding.
@@ -421,13 +422,13 @@ public class EndToEndTests extends BaseTest {
   /* Tests for masking synchronous exceptions. Termination cannot be tested here since it's in the CPUGuiThread. */
   @Test(expected = SynchronousException.class)
   public void testDivisionByZeroThrowException() throws Exception {
-    config.putBoolean("syncexc-masked", false);
+    config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, false);
     runMipsTest("div0.s");
   }
 
   @Test
   public void testDivisionByZeroNoThrowException() throws Exception {
-    config.putBoolean("syncexc-masked", true);
+    config.putBoolean(ConfigKey.SYNC_EXCEPTIONS_MASKED, true);
     runMipsTest("div0.s");
   }
 


### PR DESCRIPTION
To avoid issues like #125.
Fixes #130.

Thanks to the best refactoring tool: sed. The substitution from strings to the
corresponding ConfigKey value was done with:

for f in $(find src/main/java/org/edumips64 -name "*.java"); do
  while read -r var key; do
    sed -i $f -e "s/$var/$key";
  done < pairs;
done

Where pairs was a list of

"value" ConfigKey.VALUE

Obtained by grepping ConfigKey.java and slightly manipulating it with vim.