### PR TITLE
Always show MIPS32 register alias

### DIFF
--- a/src/main/java/org/edumips64/ui/swing/GUIConfig.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIConfig.java
@@ -242,7 +242,6 @@ public class GUIConfig extends JDialog {
     addRow(panel, row++, ConfigKey.FP_MULTIPLIER_COLOR, new JButton());
     addRow(panel, row++, ConfigKey.FP_DIVIDER_COLOR, new JButton());
     addRow(panel, row++, ConfigKey.FP_LONG_DOUBLE_VIEW, new JCheckBox());
-    addRow(panel, row++, ConfigKey.SHOW_ALIASES, new JCheckBox());
 
     // fill remaining vertical space
     grid_add(panel, new JPanel(), gbl, gbc, 0, 1, 0, row, GridBagConstraints.REMAINDER, 1);

--- a/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
+++ b/src/main/java/org/edumips64/ui/swing/GUIRegisters.java
@@ -141,7 +141,7 @@ class GUIRegisters extends GUIComponent {
       tableModel = new FileTableModel(value);
       setBackground(Color.WHITE);
       theTable = new JTable(tableModel);
-      theTable.getColumnModel().getColumn(0).setPreferredWidth(50);
+      theTable.getColumnModel().getColumn(0).setPreferredWidth(100);
       theTable.getColumnModel().getColumn(1).setPreferredWidth(147);
       theTable.getColumnModel().getColumn(2).setPreferredWidth(50);
       theTable.getColumnModel().getColumn(3).setPreferredWidth(147);
@@ -185,7 +185,7 @@ class GUIRegisters extends GUIComponent {
       //init dei vettori statici 1a e 3a colonna
       for (int i = 0; i < 32; i++) {
         numR[i] = fillFirstColumn(i);
-        numRF[i] = "F" + i + " =";
+        numRF[i] = "F" + i;
         value[i] = "0000000000000000";
 //FPU
         valueFP[i] = "0000000000000000";
@@ -198,11 +198,7 @@ class GUIRegisters extends GUIComponent {
     }
 
     String fillFirstColumn(int i) {
-      if (config.getBoolean(ConfigKey.SHOW_ALIASES)) {
-        return registerToAlias(" " + i) + "=";
-      } else {
-        return "R" + i + " =";
-      }
+      return "R" + i + (i < 10 ? " " : "") + " (" + registerToAlias(" " + i) + ")";
     }
 
     void updateRegistersNames() {

--- a/src/main/java/org/edumips64/utils/ConfigKey.java
+++ b/src/main/java/org/edumips64/utils/ConfigKey.java
@@ -30,7 +30,6 @@ public enum ConfigKey {
     SYNC_EXCEPTIONS_TERMINATE("syncexc-terminate"),
     N_STEPS("n_step"),
     SLEEP_INTERVAL("sleep_interval"),
-    SHOW_ALIASES("show_aliases"),
     FP_INVALID_OPERATION("INVALID_OPERATION"),
     FP_OVERFLOW("OVERFLOW"),
     FP_UNDERFLOW("UNDERFLOW"),

--- a/src/main/java/org/edumips64/utils/ConfigStore.java
+++ b/src/main/java/org/edumips64/utils/ConfigStore.java
@@ -65,7 +65,6 @@ public abstract class ConfigStore {
     ConfigStore.defaults.put(ConfigKey.SYNC_EXCEPTIONS_TERMINATE, false);
     ConfigStore.defaults.put(ConfigKey.N_STEPS, 4);
     ConfigStore.defaults.put(ConfigKey.SLEEP_INTERVAL, 10);
-    ConfigStore.defaults.put(ConfigKey.SHOW_ALIASES, false);
 
     // FPU exceptions defaults.
     ConfigStore.defaults.put(ConfigKey.FP_INVALID_OPERATION, true);

--- a/src/main/java/org/edumips64/utils/CurrentLocale.java
+++ b/src/main/java/org/edumips64/utils/CurrentLocale.java
@@ -156,8 +156,6 @@ public class CurrentLocale {
     en.put("Config.WARNINGS.tip", "Enable Warnings in compile time");
     en.put("Config.FORWARDING", "Enable forwarding");
     en.put("Config.FORWARDING.tip", "Enables forwarding in the pipeline");
-    en.put("Config.SHOW_ALIASES", "Use MIPS32 aliases in the Registers window");
-    en.put("Config.SHOW_ALIASES.tip", "Replaces the number of each register with its MIPS32 alias in the Registers window");
     en.put("Config.LONGDOUBLEVIEW", "Long/double mem.cells view");
     en.put("Config.LONGDOUBLEVIEW.tip", "Switchs between long and double visualisation of memory cells in the status bar");
     en.put("Config.VERBOSE", "Sync graphics with CPU in multi-step execution");
@@ -262,8 +260,6 @@ public class CurrentLocale {
 
     // Italian messages.
     HashMap<String, String> it = new HashMap<>();
-    it.put("Config.SHOW_ALIASES", "Utilizza gli alias MIPS ");
-    it.put("Config.SHOW_ALIASES.tip", "Visualizza gli alias MIPS come nomi dei registri ");
     it.put("DOUBLE_EXT_TOO_LARGE", "Esponente oltre i 32 bit");
     it.put("LABELTOOLARGE", "Numero troppo grande per una label");
     it.put("MEMORYADDRESSINVALID", "Etichetta invalida, deve essere allineata a 64 bit");
@@ -376,8 +372,6 @@ public class CurrentLocale {
     it.put("Config.WARNINGS.tip", "Abilita avvisi in fase di compilazione");
     it.put("Config.FORWARDING", "Abilita forwarding");
     it.put("Config.FORWARDING.tip", "Abilita l'opzione forwarding");
-    it.put("Config.SHOW_ALIASES", "Utilizza gli alias MIPS32 nella finestra dei registri");
-    it.put("Config.SHOW_ALIASES.tip", "Sostituisce l'alias MIPS32 di ogni registro al suo nome canonico nella finestra dei registri");
     it.put("Config.LONGDOUBLEVIEW", "Visualizza mem. Long/double");
     it.put("Config.LONGDOUBLEVIEW.tip", "Visualizza le celle di memoria come valori long o double nella barra di stato");
     it.put("Config.VERBOSE", "Sincronizza la GUI con la CPU nell'esecuzione multi-step");


### PR DESCRIPTION
Remove the useless configuration option to toggle MIPS32 aliases instead
of register numbers. We can show both.

Fixes #67