### PR TITLE
Reset the simulation if forwarding is changed

### DIFF
--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -878,10 +878,13 @@ public class Main extends JApplet {
     // ---------------- CONFIGURE MENU
 
     config.add(settings);
-    settings.addActionListener(e -> new GUIConfig(mainFrame, configStore, () -> {
+    settings.addActionListener(e -> new GUIConfig(mainFrame, configStore, (fwdChanged) -> {
       getGUIFrontend().updateComponents();
       if (cpuWorker != null) {
         cpuWorker.updateConfigValues();
+      }
+      if (fwdChanged) {
+        resetSimulator(true);
       }
     }));
     // ---------------- LANGUAGE MENU

--- a/src/main/java/org/edumips64/utils/CurrentLocale.java
+++ b/src/main/java/org/edumips64/utils/CurrentLocale.java
@@ -257,6 +257,7 @@ public class CurrentLocale {
     en.put("ISNOTALIGNED", "is not aligned to");
     en.put("RESTART_FONT", "Please restart the simulator to use the new font.");
     en.put("NO_MASK_AND_TERMINATE", "Please choose only one option between masking synchronous exceptions and program termination on synchronous exceptions.");
+    en.put("FWD_RESET_WARNING", "Changing the forwarding setting will reset the simulation. Continue?");
     languages.put("en", en);
 
     // Italian messages.
@@ -474,6 +475,7 @@ public class CurrentLocale {
     it.put("ISNOTALIGNED", "non è allineato a");
     it.put("RESTART_FONT", "E' necessario riavviare il simulatore per utilizzare il nuovo font.");
     it.put("NO_MASK_AND_TERMINATE", "Selezionare solo una opzione tra mascheramento eccezioni sincrone e terminazione in seguito ad eccezioni sincrone.");
+    it.put("FWD_RESET_WARNING", "Cambiare la modalità di forwarding indurrà un riavvio della simulazione. Continuare?");
     languages.put("it", it);
   }
 


### PR DESCRIPTION
Also warn the user before doing so and allow them to prevent this from
happening.

Fixes #98.