### PR TITLE
Prevent the instructions from changing CPU status

### DIFF
--- a/src/main/java/org/edumips64/core/is/HALT.java
+++ b/src/main/java/org/edumips64/core/is/HALT.java
@@ -49,9 +49,8 @@ public class HALT extends Instruction {
       e.printStackTrace();
     }
   }
-  public boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
-    cpu.setStatus(CPU.CPUStatus.STOPPING);
-    return false;
+  public boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException, StoppingException {
+    throw new StoppingException();
   }
 
   public void EX() throws IrregularStringOfBitsException, IntegerOverflowException, TwosComplementSumException {
@@ -61,7 +60,6 @@ public class HALT extends Instruction {
   }
 
   public void WB() throws HaltException, IrregularStringOfBitsException {
-    cpu.setStatus(CPU.CPUStatus.HALTED);
     throw new HaltException();
   }
 

--- a/src/main/java/org/edumips64/core/is/InstructionInterface.java
+++ b/src/main/java/org/edumips64/core/is/InstructionInterface.java
@@ -34,7 +34,7 @@ public interface InstructionInterface {
    * Windows).
    *</pre>
    **/
-  boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException;
+  boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException, StoppingException;
 
   /**
    * <pre>

--- a/src/main/java/org/edumips64/core/is/SYSCALL.java
+++ b/src/main/java/org/edumips64/core/is/SYSCALL.java
@@ -61,10 +61,9 @@ public class SYSCALL extends Instruction {
     }
   }
 
-  public boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException {
+  public boolean ID() throws IrregularWriteOperationException, IrregularStringOfBitsException, TwosComplementSumException, JumpException, BreakException, WAWException, FPInvalidOperationException, StoppingException {
     if (syscall_n == 0) {
-      logger.info("Stopping CPU due to SYSCALL (" + this.hashCode() + ")");
-      cpu.setStatus(CPU.CPUStatus.STOPPING);
+      throw new StoppingException();
     } else if ((syscall_n > 0) && (syscall_n <= 5)) {
       Register r14 = cpu.getRegister(14);
 
@@ -287,7 +286,6 @@ public class SYSCALL extends Instruction {
 
     if (syscall_n == 0) {
       logger.info("Stopped CPU due to SYSCALL (" + this.hashCode() + ")");
-      cpu.setStatus(CPU.CPUStatus.HALTED);
       throw new HaltException();
     } else if (syscall_n > 0 && syscall_n <= 5) {
       logger.info("SYSCALL (" + this.hashCode() + "): setting R1 to " + return_value);

--- a/src/main/java/org/edumips64/core/is/StoppingException.java
+++ b/src/main/java/org/edumips64/core/is/StoppingException.java
@@ -1,0 +1,29 @@
+/*
+ * StoppingException.java
+ *
+ * This file is part of the EduMIPS64 project, and is released under the GNU
+ * General Public License.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package org.edumips64.core.is;
+
+/**
+ * Exception thrown when an HALT / SYSCALL 0 instruction performs the ID step.
+ * When this exception is caught, the CPU should enter the STOPPING state.
+ */
+public class StoppingException extends Exception {}
+


### PR DESCRIPTION
This makes the termination flow easier to follow, as most logic is in
the CPU itself.