### PR TITLE
Don't increment cycle counter in the last cycle

### DIFF
--- a/docs/user/en/src/user-interface.rst
+++ b/docs/user/en/src/user-interface.rst
@@ -148,6 +148,11 @@ Statistics
 ~~~~~~~~~~
 The Statistics frame shows some statistics about the program execution.
 
+Note that during the last execution cycle the cycles counter is not incremented,
+because the last execution cycle is not a full CPU cycle but rather a
+pseudo-cycle whose only duties are to remove the last instruction from the
+pipeline and increment the counter of executed instructions.
+
 Pipeline
 ~~~~~~~~
 The Pipeline frame shows the actual status of the pipeline, showing which

--- a/docs/user/it/src/user-interface.rst
+++ b/docs/user/it/src/user-interface.rst
@@ -159,6 +159,11 @@ Statistics
 La finestra Statistiche mostra alcune statistiche riguardanti l'esecuzione del
 programma.
 
+Nota che durante l'ultimo ciclo di esecuzione il contatore dei cicli non viene
+incrementato, perché l'ultimo ciclo non è un vero ciclo di CPU ma solo uno
+pseudo-ciclo che ha l'unico compito di rimuovere l'ultima istruzione dalla
+pipeline ed incrementare il contatore delle istruzioni eseguite.
+
 Pipeline
 ~~~~~~~~
 La finestra Pipeline mostra lo stato attuale della pipeline, visualizzando

--- a/src/main/java/org/edumips64/core/CPU.java
+++ b/src/main/java/org/edumips64/core/CPU.java
@@ -465,6 +465,9 @@ public class CPU {
     } catch (HaltException ex) {
       setStatus(CPU.CPUStatus.HALTED);
       pipe.setWB(null);
+      // The last tick does not execute a full CPU cycle, it just removes the last instruction from the pipeline.
+      // Decrementing the cycles counter by one.
+      cycles--;
       throw ex;
 
     } finally {

--- a/src/test/java/org/edumips64/EndToEndTests.java
+++ b/src/test/java/org/edumips64/EndToEndTests.java
@@ -271,9 +271,7 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   public void testHalt() throws Exception {
       CpuTestStatus status = runMipsTest("halt.s");
 
-      // Note that the proper count here should be 5, not 6. There is a long-standing bug
-      // in cycle count, see Issue #48: https://github.com/lupino3/edumips64/issues/48.
-      collector.checkThat(status.cycles, equalTo(6));
+      collector.checkThat(status.cycles, equalTo(5));
       collector.checkThat(status.instructions, equalTo(1));
       collector.checkThat(status.memStalls, equalTo(0));
       collector.checkThat(status.rawStalls, equalTo(0));
@@ -362,11 +360,11 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   @Test
   public void testForwarding() throws Exception {
     // Simple test.
-    runForwardingTest("forwarding.s", 16, 19, 10);
+    runForwardingTest("forwarding.s", 15, 18, 10);
 
     // Tests taken from Hennessy & Patterson, Appendix A
-    runForwardingTest("forwarding-hp-pA16.s", 11, 13, 6);
-    runForwardingTest("forwarding-hp-pA18.s", 9, 13, 4);
+    runForwardingTest("forwarding-hp-pA16.s", 10, 12, 6);
+    runForwardingTest("forwarding-hp-pA18.s", 8, 12, 4);
   }
 
   @Test
@@ -381,13 +379,13 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     Map<ForwardingStatus, CpuTestStatus> statuses = runMipsTestWithAndWithoutForwarding(filename);
 
     // With forwarding
-    collector.checkThat(filename + ": cycles with forwarding.", statuses.get(ForwardingStatus.ENABLED).cycles, equalTo(20));
+    collector.checkThat(filename + ": cycles with forwarding.", statuses.get(ForwardingStatus.ENABLED).cycles, equalTo(19));
     collector.checkThat(filename + ": instructions with forwarding.", statuses.get(ForwardingStatus.ENABLED).instructions, equalTo(5));
     collector.checkThat(filename + ": WAW stalls with forwarding." ,statuses.get(ForwardingStatus.ENABLED).wawStalls, equalTo(7));
     collector.checkThat(filename + ": RAW stalls with forwarding.", statuses.get(ForwardingStatus.ENABLED).rawStalls, equalTo(1));
 
     // Without forwarding
-    collector.checkThat(filename + ": cycles without forwarding.", statuses.get(ForwardingStatus.DISABLED).cycles, equalTo(21));
+    collector.checkThat(filename + ": cycles without forwarding.", statuses.get(ForwardingStatus.DISABLED).cycles, equalTo(20));
     collector.checkThat(filename + ": instructions without forwarding.", statuses.get(ForwardingStatus.DISABLED).instructions, equalTo(5));
     collector.checkThat(filename + ": WAW stalls without forwarding." ,statuses.get(ForwardingStatus.DISABLED).wawStalls, equalTo(7));
     collector.checkThat(filename + ": RAW stalls without forwarding.", statuses.get(ForwardingStatus.DISABLED).rawStalls, equalTo(2));
@@ -403,7 +401,7 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
     Map<ForwardingStatus, CpuTestStatus> statuses = runMipsTestWithAndWithoutForwarding("fpu-mul.s");
 
     // Same behaviour with and without forwarding.
-    int expected_cycles = 43, expected_instructions = 32, expected_mem_stalls = 6;
+    int expected_cycles = 42, expected_instructions = 32, expected_mem_stalls = 6;
     collector.checkThat(statuses.get(ForwardingStatus.ENABLED).cycles, equalTo(expected_cycles));
     collector.checkThat(statuses.get(ForwardingStatus.ENABLED).instructions, equalTo(expected_instructions));
     collector.checkThat(statuses.get(ForwardingStatus.ENABLED).memStalls, equalTo(expected_mem_stalls));
@@ -529,8 +527,8 @@ public class EndToEndTests extends BaseWithInstructionBuilderTest {
   /* Issue #51: Problem with SYSCALL 0 after branch. */
   @Test
   public void testTerminationInID() throws Exception {
-    runForwardingTest("issue51-halt.s", 12, 18, 6);
-    runForwardingTest("issue51-syscall0.s", 12, 18, 6);
+    runForwardingTest("issue51-halt.s", 11, 17, 6);
+    runForwardingTest("issue51-syscall0.s", 11, 17, 6);
   }
 
   /* Issue #68: JR does not respect RAW stalls. */


### PR DESCRIPTION
This is a small hack to fix issue #48.

Fixing it in a more radical way requires a deep restructuring of the
code, which I almost finished. The restructuring is invasive, and I
don't think it's beneficial to do it, as it might introduce subtle bugs
I do not find now.

Therefore, I am choosing to not increment the cycles counter in the last
cycle, explaining it in the manual. The explanation makes sense, but the
end result is not very elegant, as when the user executes the very last
cycle they won't see the cycles counter increasing.

Also fix all tests with hardcoded number of cycles, decrementing them by
one cycle.