### PR TITLE
Minor clean-ups after the Gradle migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/*/output
 gwt-unitCache/
 war/WEB-INF/
 war/
+bin/
 
 ###############################################################################
 ## Java.gitignore from github/gitignore
@@ -46,6 +47,12 @@ war/
 # virtual machine crash logs, see
 # http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Other Java IDE files
+.classpath
+.project
+.settings
+.vscode
 
 ###############################################################################
 ## Gradle.gitignore from github/gitignore

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ mainClassName = 'org.edumips64.Main'
 version = '1.2.5'
 ext.codename = 'Eden'
 
-
 /* 
  * Documentation tasks
  */
@@ -76,6 +75,11 @@ processResources {
     }
 }
 
+// The 'classes' task is also ran by unit tests. We don't want unit tests to copy around
+// resources, especially since processResources depends on compiling the HTML docs.
+classes.dependsOn.remove('processResources')
+jar.dependsOn('processResources')
+
 def getGitRevisionId() {
   def branch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
   def commitHash = 'git rev-parse --verify --short HEAD'.execute().text.trim()
@@ -123,8 +127,9 @@ task standaloneJar(type: Jar, dependsOn: configurations.runtimeClasspath) {
         from sharedManifest        
     }
 }
+// Not sure why standaloneJar does not depend on jar. Anyway, adding this dependency for now.
+standaloneJar.dependsOn(processResources)
 assemble.dependsOn(standaloneJar) 
-
 
 /*
  * Test tasks

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@
 plugins {
     id 'java'
     id 'application'
+    id 'com.dorongold.task-tree' version '1.3.1'
 }
 
 repositories {


### PR DESCRIPTION
Even if they are not listed in #228, these minor clean-ups are still related to the migration.