### PR TITLE
Codacity fixes 00

### DIFF
--- a/src/main/java/org/edumips64/core/Converter.java
+++ b/src/main/java/org/edumips64/core/Converter.java
@@ -39,11 +39,15 @@ public class Converter {
    * @throws IrregularStringOfBitsException if the string of bits is not well-formed or the string of bits contains
    * a value that cannot be stored into an <code>int</code> variable
    */
-
   public static int binToInt(String bits, boolean unsignd) throws IrregularStringOfBitsException {
-    if ((bits.length() > 32) || (unsignd && bits.length() == 32 && bits.charAt(0) == '1') || !isBinaryString(bits)) {
+    if (bits.length() > 32) {
       throw new IrregularStringOfBitsException();
     }
+
+    if (unsignd && bits.length() == 32 && bits.charAt(0) == '1') {
+      throw new IrregularStringOfBitsException();
+    }
+
 
     //se la stringa di bits Ãš lunga 32 bit
     //ed Ãš composta da uno 1 e 31 0
@@ -51,18 +55,41 @@ public class Converter {
     //perchÃš il numero da ritornare Ãš -(2^32)
     //e non si puÃ² utilizzare il valore positivo (2^32)
     //con il tipo int :-(
-    if (!unsignd && bits.length() == 32 && bits.charAt(0) == '1' && isOverflow(bits)) {
-      return (int)(-Math.pow(2.0, 32.0));
+    if (!unsignd && bits.length() == 32 && bits.charAt(0) == '1') {
+      boolean overflow = true;
+
+      for (int i = 1; i < bits.length(); i++) {
+        if (bits.charAt(i) != '0') {
+          overflow = false;
+          break;
+        }
+      }
+
+      if (overflow) {
+        return (int)(-Math.pow(2.0, 32.0));
+      }
     }
 
+    int value = 0;
+
     if (unsignd) {
-      return getUnsignedIntValue(bits);
+      for (int j = bits.length() - 1, i = 0; j >= 0; j--, i++) {
+        if (bits.charAt(j) == '1') {
+          value += (int) Math.pow(2.0, (double) i);
+        } else if (bits.charAt(j) != '0') {
+          throw new IrregularStringOfBitsException();
+        }
+      }
+
+      return value;
     } else {
       if (bits.charAt(0) == '0') {
         return Converter.binToInt(bits.substring(1), true);
-      } else{
+      } else if (bits.charAt(0) == '1') {
         String s = Converter.twoComplement(bits);
         return -1 * Converter.binToInt(s, true);
+      } else {
+        throw new IrregularStringOfBitsException();
       }
     }
   }
@@ -78,7 +105,11 @@ public class Converter {
    * a value that cannot be stored into a <code>long</code> variable
    */
   public static long binToLong(String bits, boolean unsignd) throws IrregularStringOfBitsException {
-    if ((bits.length() > 64) || (unsignd && bits.length() == 64 && bits.charAt(0) == '1') || !isBinaryString(bits)) {
+    if (bits.length() > 64) {
+      throw new IrregularStringOfBitsException();
+    }
+
+    if (unsignd && bits.length() == 64 && bits.charAt(0) == '1') {
       throw new IrregularStringOfBitsException();
     }
 
@@ -88,22 +119,45 @@ public class Converter {
     //perchÃš il numero da ritornare Ãš -(2^63)
     //e non si puÃ² utilizzare il valore positivo (2^63)
     //con il tipo long :-(
-    if (!unsignd && bits.length() == 64 && bits.charAt(0) == '1' && isOverflow(bits)) {
-      return (long)(-Math.pow(2.0, 63.0));
+    if (!unsignd && bits.length() == 64 && bits.charAt(0) == '1') {
+      boolean overflow = true;
+
+      for (int i = 1; i < bits.length(); i++) {
+        if (bits.charAt(i) != '0') {
+          overflow = false;
+          break;
+        }
+      }
+
+      if (overflow) {
+        return (long)(-Math.pow(2.0, 63.0));
+      }
     }
+
+    long value = 0;
 
     if (bits.length() == 0) {
       return 0;
     }
 
     if (unsignd) {
-      return getUnsignedLongValue(bits);
+      for (int j = bits.length() - 1, i = 0; j >= 0; j--, i++) {
+        if (bits.charAt(j) == '1') {
+          value += (long) Math.pow(2.0, (double) i);
+        } else if (bits.charAt(j) != '0') {
+          throw new IrregularStringOfBitsException();
+        }
+      }
+
+      return value;
     } else {
       if (bits.charAt(0) == '0') {
         return Converter.binToLong(bits.substring(1), true);
-      } else {
+      } else if (bits.charAt(0) == '1') {
         String s = Converter.twoComplement(bits);
         return -1 * Converter.binToLong(s, true);
+      } else {
+        throw new IrregularStringOfBitsException();
       }
     }
   }
@@ -272,56 +326,56 @@ public class Converter {
       char toAppend = 'x';
 
       switch (value) {
-        case 0:
-          toAppend = '0';
-          break;
-        case 1:
-          toAppend = '1';
-          break;
-        case 2:
-          toAppend = '2';
-          break;
-        case 3:
-          toAppend = '3';
-          break;
-        case 4:
-          toAppend = '4';
-          break;
-        case 5:
-          toAppend = '5';
-          break;
-        case 6:
-          toAppend = '6';
-          break;
-        case 7:
-          toAppend = '7';
-          break;
-        case 8:
-          toAppend = '8';
-          break;
-        case 9:
-          toAppend = '9';
-          break;
-        case 10:
-          toAppend = 'A';
-          break;
-        case 11:
-          toAppend = 'B';
-          break;
-        case 12:
-          toAppend = 'C';
-          break;
-        case 13:
-          toAppend = 'D';
-          break;
-        case 14:
-          toAppend = 'E';
-          break;
-        case 15:
-          toAppend = 'F';
-          break;
-        default:
-          throw new IrregularStringOfBitsException();
+      case 0:
+        toAppend = '0';
+        break;
+      case 1:
+        toAppend = '1';
+        break;
+      case 2:
+        toAppend = '2';
+        break;
+      case 3:
+        toAppend = '3';
+        break;
+      case 4:
+        toAppend = '4';
+        break;
+      case 5:
+        toAppend = '5';
+        break;
+      case 6:
+        toAppend = '6';
+        break;
+      case 7:
+        toAppend = '7';
+        break;
+      case 8:
+        toAppend = '8';
+        break;
+      case 9:
+        toAppend = '9';
+        break;
+      case 10:
+        toAppend = 'A';
+        break;
+      case 11:
+        toAppend = 'B';
+        break;
+      case 12:
+        toAppend = 'C';
+        break;
+      case 13:
+        toAppend = 'D';
+        break;
+      case 14:
+        toAppend = 'E';
+        break;
+      case 15:
+        toAppend = 'F';
+        break;
+      default:
+        throw new IrregularStringOfBitsException();
       }
 
       ret.append(toAppend);
@@ -334,7 +388,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToShort(String hex) throws IrregularStringOfHexException {
     if (hex.charAt(0) != '0' || hex.toUpperCase().charAt(1) != 'X') {
@@ -349,56 +403,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-        case '0':
-          ret += 0 * powLong(16, reversecont);
-          break;
-        case '1':
-          ret += 1 * powLong(16, reversecont);
-          break;
-        case '2':
-          ret += 2 * powLong(16, reversecont);
-          break;
-        case '3':
-          ret += 3 * powLong(16, reversecont);
-          break;
-        case '4':
-          ret += 4 * powLong(16, reversecont);
-          break;
-        case '5':
-          ret += 5 * powLong(16, reversecont);
-          break;
-        case '6':
-          ret += 6 * powLong(16, reversecont);
-          break;
-        case '7':
-          ret += 7 * powLong(16, reversecont);
-          break;
-        case '8':
-          ret += 8 * powLong(16, reversecont);
-          break;
-        case '9':
-          ret += 9 * powLong(16, reversecont);
-          break;
-        case 'A':
-          ret += 10 * powLong(16, reversecont);
-          break;
-        case 'B':
-          ret += 11 * powLong(16, reversecont);
-          break;
-        case 'C':
-          ret += 12 * powLong(16, reversecont);
-          break;
-        case 'D':
-          ret += 13 * powLong(16, reversecont);
-          break;
-        case 'E':
-          ret += 14 * powLong(16, reversecont);
-          break;
-        case 'F':
-          ret += 15 * powLong(16, reversecont);
-          break;
-        default:
-          throw new IrregularStringOfHexException();
+      case '0':
+        ret += 0 * powLong(16, reversecont);
+        break;
+      case '1':
+        ret += 1 * powLong(16, reversecont);
+        break;
+      case '2':
+        ret += 2 * powLong(16, reversecont);
+        break;
+      case '3':
+        ret += 3 * powLong(16, reversecont);
+        break;
+      case '4':
+        ret += 4 * powLong(16, reversecont);
+        break;
+      case '5':
+        ret += 5 * powLong(16, reversecont);
+        break;
+      case '6':
+        ret += 6 * powLong(16, reversecont);
+        break;
+      case '7':
+        ret += 7 * powLong(16, reversecont);
+        break;
+      case '8':
+        ret += 8 * powLong(16, reversecont);
+        break;
+      case '9':
+        ret += 9 * powLong(16, reversecont);
+        break;
+      case 'A':
+        ret += 10 * powLong(16, reversecont);
+        break;
+      case 'B':
+        ret += 11 * powLong(16, reversecont);
+        break;
+      case 'C':
+        ret += 12 * powLong(16, reversecont);
+        break;
+      case 'D':
+        ret += 13 * powLong(16, reversecont);
+        break;
+      case 'E':
+        ret += 14 * powLong(16, reversecont);
+        break;
+      case 'F':
+        ret += 15 * powLong(16, reversecont);
+        break;
+      default:
+        throw new IrregularStringOfHexException();
       }
 
     }
@@ -410,7 +464,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToLong(String hex) throws IrregularStringOfHexException {
 
@@ -426,56 +480,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-        case '0':
-          ret += 0 * powLong(16, reversecont);
-          break;
-        case '1':
-          ret += 1 * powLong(16, reversecont);
-          break;
-        case '2':
-          ret += 2 * powLong(16, reversecont);
-          break;
-        case '3':
-          ret += 3 * powLong(16, reversecont);
-          break;
-        case '4':
-          ret += 4 * powLong(16, reversecont);
-          break;
-        case '5':
-          ret += 5 * powLong(16, reversecont);
-          break;
-        case '6':
-          ret += 6 * powLong(16, reversecont);
-          break;
-        case '7':
-          ret += 7 * powLong(16, reversecont);
-          break;
-        case '8':
-          ret += 8 * powLong(16, reversecont);
-          break;
-        case '9':
-          ret += 9 * powLong(16, reversecont);
-          break;
-        case 'A':
-          ret += 10 * powLong(16, reversecont);
-          break;
-        case 'B':
-          ret += 11 * powLong(16, reversecont);
-          break;
-        case 'C':
-          ret += 12 * powLong(16, reversecont);
-          break;
-        case 'D':
-          ret += 13 * powLong(16, reversecont);
-          break;
-        case 'E':
-          ret += 14 * powLong(16, reversecont);
-          break;
-        case 'F':
-          ret += 15 * powLong(16, reversecont);
-          break;
-        default:
-          throw new IrregularStringOfHexException();
+      case '0':
+        ret += 0 * powLong(16, reversecont);
+        break;
+      case '1':
+        ret += 1 * powLong(16, reversecont);
+        break;
+      case '2':
+        ret += 2 * powLong(16, reversecont);
+        break;
+      case '3':
+        ret += 3 * powLong(16, reversecont);
+        break;
+      case '4':
+        ret += 4 * powLong(16, reversecont);
+        break;
+      case '5':
+        ret += 5 * powLong(16, reversecont);
+        break;
+      case '6':
+        ret += 6 * powLong(16, reversecont);
+        break;
+      case '7':
+        ret += 7 * powLong(16, reversecont);
+        break;
+      case '8':
+        ret += 8 * powLong(16, reversecont);
+        break;
+      case '9':
+        ret += 9 * powLong(16, reversecont);
+        break;
+      case 'A':
+        ret += 10 * powLong(16, reversecont);
+        break;
+      case 'B':
+        ret += 11 * powLong(16, reversecont);
+        break;
+      case 'C':
+        ret += 12 * powLong(16, reversecont);
+        break;
+      case 'D':
+        ret += 13 * powLong(16, reversecont);
+        break;
+      case 'E':
+        ret += 14 * powLong(16, reversecont);
+        break;
+      case 'F':
+        ret += 15 * powLong(16, reversecont);
+        break;
+      default:
+        throw new IrregularStringOfHexException();
       }
 
     }
@@ -487,7 +541,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToBin(String hex) throws IrregularStringOfHexException {
 
@@ -498,56 +552,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-        case '0':
-          ret += "0000";
-          break;
-        case '1':
-          ret += "0001";
-          break;
-        case '2':
-          ret += "0010";
-          break;
-        case '3':
-          ret += "0011";
-          break;
-        case '4':
-          ret += "0100";
-          break;
-        case '5':
-          ret += "0101";
-          break;
-        case '6':
-          ret += "0110";
-          break;
-        case '7':
-          ret += "0111";
-          break;
-        case '8':
-          ret += "1000";
-          break;
-        case '9':
-          ret += "1001";
-          break;
-        case 'A':
-          ret += "1010";
-          break;
-        case 'B':
-          ret += "1011";
-          break;
-        case 'C':
-          ret += "1100";
-          break;
-        case 'D':
-          ret += "1101";
-          break;
-        case 'E':
-          ret += "1110";
-          break;
-        case 'F':
-          ret += "1111";
-          break;
-        default:
-          throw new IrregularStringOfHexException();
+      case '0':
+        ret += "0000";
+        break;
+      case '1':
+        ret += "0001";
+        break;
+      case '2':
+        ret += "0010";
+        break;
+      case '3':
+        ret += "0011";
+        break;
+      case '4':
+        ret += "0100";
+        break;
+      case '5':
+        ret += "0101";
+        break;
+      case '6':
+        ret += "0110";
+        break;
+      case '7':
+        ret += "0111";
+        break;
+      case '8':
+        ret += "1000";
+        break;
+      case '9':
+        ret += "1001";
+        break;
+      case 'A':
+        ret += "1010";
+        break;
+      case 'B':
+        ret += "1011";
+        break;
+      case 'C':
+        ret += "1100";
+        break;
+      case 'D':
+        ret += "1101";
+        break;
+      case 'E':
+        ret += "1110";
+        break;
+      case 'F':
+        ret += "1111";
+        break;
+      default:
+        throw new IrregularStringOfHexException();
       }
 
     }
@@ -562,49 +616,6 @@ public class Converter {
     }
 
     return ret;
-  }
-
-  private static boolean isBinaryString(String bits) {
-    char bit;
-    for (int i = 0; i < bits.length(); i++) {
-      bit = bits.charAt(i);
-      if (bit != '0' && bit != '1') {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static boolean isOverflow(String bits){
-    for (int i = 1; i < bits.length(); i++) {
-      if (bits.charAt(i) != '0') {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static int getUnsignedIntValue(String bits){
-    int value = 0;
-    int i = 0;
-    for (int j = bits.length() - 1; j >= 0; j--, i++) {
-      if (bits.charAt(j) == '1') {
-        value += (int) Math.pow(2.0, (double) i);
-      }
-    }
-    return value;
-  }
-
-  private static long getUnsignedLongValue(String bits){
-    long value = 0;
-    int i = 0;
-    for (int j = bits.length() - 1; j >= 0; j--, i++) {
-      if (bits.charAt(j) == '1') {
-        value += (long) Math.pow(2.0, (double) i);
-      }
-    }
-
-    return value;
   }
 }
 

--- a/src/main/java/org/edumips64/core/Converter.java
+++ b/src/main/java/org/edumips64/core/Converter.java
@@ -39,15 +39,11 @@ public class Converter {
    * @throws IrregularStringOfBitsException if the string of bits is not well-formed or the string of bits contains
    * a value that cannot be stored into an <code>int</code> variable
    */
+
   public static int binToInt(String bits, boolean unsignd) throws IrregularStringOfBitsException {
-    if (bits.length() > 32) {
+    if ((bits.length() > 32) || (unsignd && bits.length() == 32 && bits.charAt(0) == '1') || !isBinaryString(bits)) {
       throw new IrregularStringOfBitsException();
     }
-
-    if (unsignd && bits.length() == 32 && bits.charAt(0) == '1') {
-      throw new IrregularStringOfBitsException();
-    }
-
 
     //se la stringa di bits Ãš lunga 32 bit
     //ed Ãš composta da uno 1 e 31 0
@@ -55,41 +51,18 @@ public class Converter {
     //perchÃš il numero da ritornare Ãš -(2^32)
     //e non si puÃ² utilizzare il valore positivo (2^32)
     //con il tipo int :-(
-    if (!unsignd && bits.length() == 32 && bits.charAt(0) == '1') {
-      boolean overflow = true;
-
-      for (int i = 1; i < bits.length(); i++) {
-        if (bits.charAt(i) != '0') {
-          overflow = false;
-          break;
-        }
-      }
-
-      if (overflow) {
-        return (int)(-Math.pow(2.0, 32.0));
-      }
+    if (!unsignd && bits.length() == 32 && bits.charAt(0) == '1' && isOverflow(bits)) {
+      return (int)(-Math.pow(2.0, 32.0));
     }
 
-    int value = 0;
-
     if (unsignd) {
-      for (int j = bits.length() - 1, i = 0; j >= 0; j--, i++) {
-        if (bits.charAt(j) == '1') {
-          value += (int) Math.pow(2.0, (double) i);
-        } else if (bits.charAt(j) != '0') {
-          throw new IrregularStringOfBitsException();
-        }
-      }
-
-      return value;
+      return getUnsignedIntValue(bits);
     } else {
       if (bits.charAt(0) == '0') {
         return Converter.binToInt(bits.substring(1), true);
-      } else if (bits.charAt(0) == '1') {
+      } else{
         String s = Converter.twoComplement(bits);
         return -1 * Converter.binToInt(s, true);
-      } else {
-        throw new IrregularStringOfBitsException();
       }
     }
   }
@@ -105,11 +78,7 @@ public class Converter {
    * a value that cannot be stored into a <code>long</code> variable
    */
   public static long binToLong(String bits, boolean unsignd) throws IrregularStringOfBitsException {
-    if (bits.length() > 64) {
-      throw new IrregularStringOfBitsException();
-    }
-
-    if (unsignd && bits.length() == 64 && bits.charAt(0) == '1') {
+    if ((bits.length() > 64) || (unsignd && bits.length() == 64 && bits.charAt(0) == '1') || !isBinaryString(bits)) {
       throw new IrregularStringOfBitsException();
     }
 
@@ -119,45 +88,22 @@ public class Converter {
     //perchÃš il numero da ritornare Ãš -(2^63)
     //e non si puÃ² utilizzare il valore positivo (2^63)
     //con il tipo long :-(
-    if (!unsignd && bits.length() == 64 && bits.charAt(0) == '1') {
-      boolean overflow = true;
-
-      for (int i = 1; i < bits.length(); i++) {
-        if (bits.charAt(i) != '0') {
-          overflow = false;
-          break;
-        }
-      }
-
-      if (overflow) {
-        return (long)(-Math.pow(2.0, 63.0));
-      }
+    if (!unsignd && bits.length() == 64 && bits.charAt(0) == '1' && isOverflow(bits)) {
+      return (long)(-Math.pow(2.0, 63.0));
     }
-
-    long value = 0;
 
     if (bits.length() == 0) {
       return 0;
     }
 
     if (unsignd) {
-      for (int j = bits.length() - 1, i = 0; j >= 0; j--, i++) {
-        if (bits.charAt(j) == '1') {
-          value += (long) Math.pow(2.0, (double) i);
-        } else if (bits.charAt(j) != '0') {
-          throw new IrregularStringOfBitsException();
-        }
-      }
-
-      return value;
+      return getUnsignedLongValue(bits);
     } else {
       if (bits.charAt(0) == '0') {
         return Converter.binToLong(bits.substring(1), true);
-      } else if (bits.charAt(0) == '1') {
+      } else {
         String s = Converter.twoComplement(bits);
         return -1 * Converter.binToLong(s, true);
-      } else {
-        throw new IrregularStringOfBitsException();
       }
     }
   }
@@ -326,56 +272,56 @@ public class Converter {
       char toAppend = 'x';
 
       switch (value) {
-      case 0:
-        toAppend = '0';
-        break;
-      case 1:
-        toAppend = '1';
-        break;
-      case 2:
-        toAppend = '2';
-        break;
-      case 3:
-        toAppend = '3';
-        break;
-      case 4:
-        toAppend = '4';
-        break;
-      case 5:
-        toAppend = '5';
-        break;
-      case 6:
-        toAppend = '6';
-        break;
-      case 7:
-        toAppend = '7';
-        break;
-      case 8:
-        toAppend = '8';
-        break;
-      case 9:
-        toAppend = '9';
-        break;
-      case 10:
-        toAppend = 'A';
-        break;
-      case 11:
-        toAppend = 'B';
-        break;
-      case 12:
-        toAppend = 'C';
-        break;
-      case 13:
-        toAppend = 'D';
-        break;
-      case 14:
-        toAppend = 'E';
-        break;
-      case 15:
-        toAppend = 'F';
-        break;
-      default:
-        throw new IrregularStringOfBitsException();
+        case 0:
+          toAppend = '0';
+          break;
+        case 1:
+          toAppend = '1';
+          break;
+        case 2:
+          toAppend = '2';
+          break;
+        case 3:
+          toAppend = '3';
+          break;
+        case 4:
+          toAppend = '4';
+          break;
+        case 5:
+          toAppend = '5';
+          break;
+        case 6:
+          toAppend = '6';
+          break;
+        case 7:
+          toAppend = '7';
+          break;
+        case 8:
+          toAppend = '8';
+          break;
+        case 9:
+          toAppend = '9';
+          break;
+        case 10:
+          toAppend = 'A';
+          break;
+        case 11:
+          toAppend = 'B';
+          break;
+        case 12:
+          toAppend = 'C';
+          break;
+        case 13:
+          toAppend = 'D';
+          break;
+        case 14:
+          toAppend = 'E';
+          break;
+        case 15:
+          toAppend = 'F';
+          break;
+        default:
+          throw new IrregularStringOfBitsException();
       }
 
       ret.append(toAppend);
@@ -388,7 +334,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToShort(String hex) throws IrregularStringOfHexException {
     if (hex.charAt(0) != '0' || hex.toUpperCase().charAt(1) != 'X') {
@@ -403,56 +349,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-      case '0':
-        ret += 0 * powLong(16, reversecont);
-        break;
-      case '1':
-        ret += 1 * powLong(16, reversecont);
-        break;
-      case '2':
-        ret += 2 * powLong(16, reversecont);
-        break;
-      case '3':
-        ret += 3 * powLong(16, reversecont);
-        break;
-      case '4':
-        ret += 4 * powLong(16, reversecont);
-        break;
-      case '5':
-        ret += 5 * powLong(16, reversecont);
-        break;
-      case '6':
-        ret += 6 * powLong(16, reversecont);
-        break;
-      case '7':
-        ret += 7 * powLong(16, reversecont);
-        break;
-      case '8':
-        ret += 8 * powLong(16, reversecont);
-        break;
-      case '9':
-        ret += 9 * powLong(16, reversecont);
-        break;
-      case 'A':
-        ret += 10 * powLong(16, reversecont);
-        break;
-      case 'B':
-        ret += 11 * powLong(16, reversecont);
-        break;
-      case 'C':
-        ret += 12 * powLong(16, reversecont);
-        break;
-      case 'D':
-        ret += 13 * powLong(16, reversecont);
-        break;
-      case 'E':
-        ret += 14 * powLong(16, reversecont);
-        break;
-      case 'F':
-        ret += 15 * powLong(16, reversecont);
-        break;
-      default:
-        throw new IrregularStringOfHexException();
+        case '0':
+          ret += 0 * powLong(16, reversecont);
+          break;
+        case '1':
+          ret += 1 * powLong(16, reversecont);
+          break;
+        case '2':
+          ret += 2 * powLong(16, reversecont);
+          break;
+        case '3':
+          ret += 3 * powLong(16, reversecont);
+          break;
+        case '4':
+          ret += 4 * powLong(16, reversecont);
+          break;
+        case '5':
+          ret += 5 * powLong(16, reversecont);
+          break;
+        case '6':
+          ret += 6 * powLong(16, reversecont);
+          break;
+        case '7':
+          ret += 7 * powLong(16, reversecont);
+          break;
+        case '8':
+          ret += 8 * powLong(16, reversecont);
+          break;
+        case '9':
+          ret += 9 * powLong(16, reversecont);
+          break;
+        case 'A':
+          ret += 10 * powLong(16, reversecont);
+          break;
+        case 'B':
+          ret += 11 * powLong(16, reversecont);
+          break;
+        case 'C':
+          ret += 12 * powLong(16, reversecont);
+          break;
+        case 'D':
+          ret += 13 * powLong(16, reversecont);
+          break;
+        case 'E':
+          ret += 14 * powLong(16, reversecont);
+          break;
+        case 'F':
+          ret += 15 * powLong(16, reversecont);
+          break;
+        default:
+          throw new IrregularStringOfHexException();
       }
 
     }
@@ -464,7 +410,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToLong(String hex) throws IrregularStringOfHexException {
 
@@ -480,56 +426,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-      case '0':
-        ret += 0 * powLong(16, reversecont);
-        break;
-      case '1':
-        ret += 1 * powLong(16, reversecont);
-        break;
-      case '2':
-        ret += 2 * powLong(16, reversecont);
-        break;
-      case '3':
-        ret += 3 * powLong(16, reversecont);
-        break;
-      case '4':
-        ret += 4 * powLong(16, reversecont);
-        break;
-      case '5':
-        ret += 5 * powLong(16, reversecont);
-        break;
-      case '6':
-        ret += 6 * powLong(16, reversecont);
-        break;
-      case '7':
-        ret += 7 * powLong(16, reversecont);
-        break;
-      case '8':
-        ret += 8 * powLong(16, reversecont);
-        break;
-      case '9':
-        ret += 9 * powLong(16, reversecont);
-        break;
-      case 'A':
-        ret += 10 * powLong(16, reversecont);
-        break;
-      case 'B':
-        ret += 11 * powLong(16, reversecont);
-        break;
-      case 'C':
-        ret += 12 * powLong(16, reversecont);
-        break;
-      case 'D':
-        ret += 13 * powLong(16, reversecont);
-        break;
-      case 'E':
-        ret += 14 * powLong(16, reversecont);
-        break;
-      case 'F':
-        ret += 15 * powLong(16, reversecont);
-        break;
-      default:
-        throw new IrregularStringOfHexException();
+        case '0':
+          ret += 0 * powLong(16, reversecont);
+          break;
+        case '1':
+          ret += 1 * powLong(16, reversecont);
+          break;
+        case '2':
+          ret += 2 * powLong(16, reversecont);
+          break;
+        case '3':
+          ret += 3 * powLong(16, reversecont);
+          break;
+        case '4':
+          ret += 4 * powLong(16, reversecont);
+          break;
+        case '5':
+          ret += 5 * powLong(16, reversecont);
+          break;
+        case '6':
+          ret += 6 * powLong(16, reversecont);
+          break;
+        case '7':
+          ret += 7 * powLong(16, reversecont);
+          break;
+        case '8':
+          ret += 8 * powLong(16, reversecont);
+          break;
+        case '9':
+          ret += 9 * powLong(16, reversecont);
+          break;
+        case 'A':
+          ret += 10 * powLong(16, reversecont);
+          break;
+        case 'B':
+          ret += 11 * powLong(16, reversecont);
+          break;
+        case 'C':
+          ret += 12 * powLong(16, reversecont);
+          break;
+        case 'D':
+          ret += 13 * powLong(16, reversecont);
+          break;
+        case 'E':
+          ret += 14 * powLong(16, reversecont);
+          break;
+        case 'F':
+          ret += 15 * powLong(16, reversecont);
+          break;
+        default:
+          throw new IrregularStringOfHexException();
       }
 
     }
@@ -541,7 +487,7 @@ public class Converter {
    * @param hex string of hexadecimal, must start whith a 'x' or a 'X' and continue with only [0-9] or [A-F] (or [a-f]) chars, otherwise
    * an IrregularStringOfHexException exception will be thrown.
    * @return string of long digit [0-9].
-   * @throws IrregularStringOHexException if the string of hexadecimal is not well-formed.
+   * @throws IrregularStringOfHexException if the string of hexadecimal is not well-formed.
    */
   public static String hexToBin(String hex) throws IrregularStringOfHexException {
 
@@ -552,56 +498,56 @@ public class Converter {
       char value = hex.toUpperCase().charAt(i);
 
       switch (value) {
-      case '0':
-        ret += "0000";
-        break;
-      case '1':
-        ret += "0001";
-        break;
-      case '2':
-        ret += "0010";
-        break;
-      case '3':
-        ret += "0011";
-        break;
-      case '4':
-        ret += "0100";
-        break;
-      case '5':
-        ret += "0101";
-        break;
-      case '6':
-        ret += "0110";
-        break;
-      case '7':
-        ret += "0111";
-        break;
-      case '8':
-        ret += "1000";
-        break;
-      case '9':
-        ret += "1001";
-        break;
-      case 'A':
-        ret += "1010";
-        break;
-      case 'B':
-        ret += "1011";
-        break;
-      case 'C':
-        ret += "1100";
-        break;
-      case 'D':
-        ret += "1101";
-        break;
-      case 'E':
-        ret += "1110";
-        break;
-      case 'F':
-        ret += "1111";
-        break;
-      default:
-        throw new IrregularStringOfHexException();
+        case '0':
+          ret += "0000";
+          break;
+        case '1':
+          ret += "0001";
+          break;
+        case '2':
+          ret += "0010";
+          break;
+        case '3':
+          ret += "0011";
+          break;
+        case '4':
+          ret += "0100";
+          break;
+        case '5':
+          ret += "0101";
+          break;
+        case '6':
+          ret += "0110";
+          break;
+        case '7':
+          ret += "0111";
+          break;
+        case '8':
+          ret += "1000";
+          break;
+        case '9':
+          ret += "1001";
+          break;
+        case 'A':
+          ret += "1010";
+          break;
+        case 'B':
+          ret += "1011";
+          break;
+        case 'C':
+          ret += "1100";
+          break;
+        case 'D':
+          ret += "1101";
+          break;
+        case 'E':
+          ret += "1110";
+          break;
+        case 'F':
+          ret += "1111";
+          break;
+        default:
+          throw new IrregularStringOfHexException();
       }
 
     }
@@ -616,6 +562,49 @@ public class Converter {
     }
 
     return ret;
+  }
+
+  private static boolean isBinaryString(String bits) {
+    char bit;
+    for (int i = 0; i < bits.length(); i++) {
+      bit = bits.charAt(i);
+      if (bit != '0' && bit != '1') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isOverflow(String bits){
+    for (int i = 1; i < bits.length(); i++) {
+      if (bits.charAt(i) != '0') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int getUnsignedIntValue(String bits){
+    int value = 0;
+    int i = 0;
+    for (int j = bits.length() - 1; j >= 0; j--, i++) {
+      if (bits.charAt(j) == '1') {
+        value += (int) Math.pow(2.0, (double) i);
+      }
+    }
+    return value;
+  }
+
+  private static long getUnsignedLongValue(String bits){
+    long value = 0;
+    int i = 0;
+    for (int j = bits.length() - 1; j >= 0; j--, i++) {
+      if (bits.charAt(j) == '1') {
+        value += (long) Math.pow(2.0, (double) i);
+      }
+    }
+
+    return value;
   }
 }
 

--- a/src/main/java/org/edumips64/core/fpu/RegisterFP.java
+++ b/src/main/java/org/edumips64/core/fpu/RegisterFP.java
@@ -110,7 +110,7 @@ public class RegisterFP extends BitSet64FP {
 
 
   public String toString() {
-    String s = new String();
+    String s = "";
 
     try {
       s = getHexString();

--- a/src/main/java/org/edumips64/core/is/DSRA.java
+++ b/src/main/java/org/edumips64/core/is/DSRA.java
@@ -35,16 +35,16 @@ import org.edumips64.core.fpu.FPInvalidOperationException;
  * @author Trubia Massimo, Russo Daniele
  */
 public class DSRA extends ALU_RType {
-  final int RD_FIELD = 0;
-  final int RT_FIELD = 1;
-  final int SA_FIELD = 2;
-  final int RD_FIELD_INIT = 16;
-  final int RT_FIELD_INIT = 11;
-  final int SA_FIELD_INIT = 21;
-  final int RD_FIELD_LENGTH = 5;
-  final int RT_FIELD_LENGTH = 5;
-  final int SA_FIELD_LENGTH = 5;
-  final String OPCODE_VALUE = "111011";
+  private final int RD_FIELD = 0;
+  private final int RT_FIELD = 1;
+  private final int SA_FIELD = 2;
+  private final int RD_FIELD_INIT = 16;
+  private final int RT_FIELD_INIT = 11;
+  private final int SA_FIELD_INIT = 21;
+  private final int RD_FIELD_LENGTH = 5;
+  private final int RT_FIELD_LENGTH = 5;
+  private final int SA_FIELD_LENGTH = 5;
+  private final String OPCODE_VALUE = "111011";
 
   DSRA() {
     super.OPCODE_VALUE = OPCODE_VALUE;

--- a/src/main/java/org/edumips64/core/is/DSRAV.java
+++ b/src/main/java/org/edumips64/core/is/DSRAV.java
@@ -39,16 +39,10 @@ import org.edumips64.core.IrregularStringOfBitsException;
  * @author Trubia Massimo, Russo Daniele
  */
 public class DSRAV extends ALU_RType {
-  final int RD_FIELD = 0;
-  final int RT_FIELD = 1;
-  final int RS_FIELD = 2;
-  final int RD_FIELD_INIT = 11;
-  final int RT_FIELD_INIT = 16;
-  final int RS_FIELD_INIT = 21;
-  final int RD_FIELD_LENGTH = 5;
-  final int RT_FIELD_LENGTH = 5;
-  final int RS_FIELD_LENGTH = 5;
-  final String OPCODE_VALUE = "010111";
+  private final int RD_FIELD = 0;
+  private final int RT_FIELD = 1;
+  private final int RS_FIELD = 2;
+  private final String OPCODE_VALUE = "010111";
 
   DSRAV() {
     super.OPCODE_VALUE = OPCODE_VALUE;

--- a/src/main/java/org/edumips64/core/is/DSRLV.java
+++ b/src/main/java/org/edumips64/core/is/DSRLV.java
@@ -39,16 +39,10 @@ import org.edumips64.core.IrregularStringOfBitsException;
  * @author Trubia Massimo, Russo Daniele
  **/
 public class DSRLV extends ALU_RType {
-  final int RD_FIELD = 0;
-  final int RT_FIELD = 1;
-  final int RS_FIELD = 2;
-  final int RD_FIELD_INIT = 11;
-  final int RT_FIELD_INIT = 16;
-  final int RS_FIELD_INIT = 21;
-  final int RD_FIELD_LENGTH = 5;
-  final int RT_FIELD_LENGTH = 5;
-  final int RS_FIELD_LENGTH = 5;
-  final String OPCODE_VALUE = "010110";
+  private final int RD_FIELD = 0;
+  private final int RT_FIELD = 1;
+  private final int RS_FIELD = 2;
+  private final String OPCODE_VALUE = "010110";
   DSRLV() {
     super.OPCODE_VALUE = OPCODE_VALUE;
     name = "DSRLV";

--- a/src/main/java/org/edumips64/core/is/SRLV.java
+++ b/src/main/java/org/edumips64/core/is/SRLV.java
@@ -37,16 +37,10 @@ import org.edumips64.core.IrregularStringOfBitsException;
  * @author UrzÃ¬ Erik - Sciuto Lorenzo - Giorgio Scibilia
  */
 public class SRLV extends ALU_RType {
-  final int RD_FIELD = 0;
-  final int RT_FIELD = 1;
-  final int RS_FIELD = 2;
-  final int RD_FIELD_INIT = 11;
-  final int RT_FIELD_INIT = 16;
-  final int RS_FIELD_INIT = 21;
-  final int RD_FIELD_LENGTH = 5;
-  final int RT_FIELD_LENGTH = 5;
-  final int RS_FIELD_LENGTH = 5;
-  final String OPCODE_VALUE = "000110";
+  private final int RD_FIELD = 0;
+  private final int RT_FIELD = 1;
+  private final int RS_FIELD = 2;
+  private final String OPCODE_VALUE = "000110";
 
   SRLV() {
     super.OPCODE_VALUE = OPCODE_VALUE;


### PR DESCRIPTION
Hello, question about this before I continue: several of the ALU_RType files have the same kind of Codacity recommendations as these. It complains that the final int fields aren't explicitly scoped, and then when I make them private, it complains that they are unused. For these files, I removed them, but since there are so many like this I wanted to see if you want to address it this way or not. I was thinking you might have a reason to ignore these errors for now and leave the fields in place.

Thanks.

Howard