### PR TITLE
Publish build artifacts on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 pool:
   vmImage: 'Ubuntu-16.04'
 
-# JDK 1.9 and 1.10 are out of support on Azure Pipeline tasks 
+# JDK 1.9 and 1.10 are out of support on Azure Pipeline tasks
 strategy:
   matrix:
     jdk_8:
@@ -20,14 +20,13 @@ strategy:
 
 steps:
 - bash: |
-      sudo apt update && 
+      sudo apt update &&
       sudo apt install python3-sphinx latexmk texlive-latex-base texlive-latex-extra texlive-fonts-extra texlive-fonts-recommended texlive-lang-english texlive-lang-italian texlive-xetex
   displayName: 'Install dependencies'
 
 - task: Gradle@2
   displayName: 'Gradle check task'
   inputs:
-    workingDirectory: ''
     gradleWrapperFile: 'gradlew'
     gradleOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
@@ -43,3 +42,17 @@ steps:
   displayName: 'Codecov update'
   env:
     CODECOV_TOKEN: $(codecov_token)
+
+- task: Gradle@2
+  displayName: 'Create standalone JAR'
+  inputs:
+    gradleWrapperFile: 'gradlew'
+    gradleOptions: '-Xmx3072m'
+    javaHomeOption: 'JDKVersion'
+    jdkVersionOption: $(jdk_ver)
+    jdkArchitectureOption: 'x64'
+    tasks: 'standaloneJar'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: './build/libs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,12 @@ pool:
 # JDK 1.9 and 1.10 are out of support on Azure Pipeline tasks
 strategy:
   matrix:
-    jdk_8:
-        jdk_ver: '1.8'
-    jdk_11:
-        jdk_ver: '1.11'
+    JDK-8:
+        jdk-ver: '1.8'
+        artifact-name: 'edumips64-jdk8'
+    JDK-11:
+        jdk-ver: '1.11'
+        artifact-name: 'edumips64-jdk11'
 
 
 steps:
@@ -30,13 +32,11 @@ steps:
     gradleWrapperFile: 'gradlew'
     gradleOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: $(jdk_ver)
+    jdkVersionOption: $(jdk-ver)
     jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
+    publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'check'
-
-- task: PublishTestResults@2
 
 - script: bash <(curl -s https://codecov.io/bash)
   displayName: 'Codecov update'
@@ -49,10 +49,12 @@ steps:
     gradleWrapperFile: 'gradlew'
     gradleOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: $(jdk_ver)
+    jdkVersionOption: $(jdk-ver)
     jdkArchitectureOption: 'x64'
     tasks: 'standaloneJar'
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathToPublish: './build/libs'
+    pathtoPublish: './build/libs'
+    artifactName: $(artifact-name)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,20 @@ steps:
     tasks: 'standaloneJar'
 
 - task: PublishBuildArtifacts@1
+  displayName: 'Publish standalone artifact'
   inputs:
     pathtoPublish: './build/libs'
+    artifactName: $(artifact-name)
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish English manual'
+  inputs:
+    pathtoPublish: './build/docs/en/latex/EduMIPS64.pdf'
+    artifactName: $(artifact-name)
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Italian manual'
+  inputs:
+    pathtoPublish: './build/docs/it/latex/EduMIPS64.pdf'
     artifactName: $(artifact-name)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,17 +57,17 @@ steps:
   displayName: 'Publish standalone artifact'
   inputs:
     pathtoPublish: './build/libs'
-    artifactName: $(artifact-name)
+    artifactName: '$(artifact-name)-standalone'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish English manual'
   inputs:
     pathtoPublish: './build/docs/en/latex/EduMIPS64.pdf'
-    artifactName: $(artifact-name)
+    artifactName: 'edumips64-docs-en'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Italian manual'
   inputs:
     pathtoPublish: './build/docs/it/latex/EduMIPS64.pdf'
-    artifactName: $(artifact-name)
+    artifactName: 'edumips64-docs-it'
 


### PR DESCRIPTION
Publish the following artifacts upon CI/CD build:
- [x] standalone JARs for both builds (JDK 8 and 11)
- [x] PDFs of English and Italian manuals

![image](https://user-images.githubusercontent.com/1350095/67244543-d4ba0580-f451-11e9-9836-43e8e4ac0bb5.png)


Close #245 .