### PR TITLE
Improve ReportDialog

### DIFF
--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -55,10 +55,10 @@ import javax.swing.event.*;
 
 public class Main extends JApplet {
 
-  private static String VERSION;
-  private static String CODENAME;
-  private static String BUILD_DATE;
-  private static String GIT_REVISION;
+  public static String VERSION;
+  public static String CODENAME;
+  public static String BUILD_DATE;
+  public static String GIT_REVISION;
 
   private static CPU cpu;
   // The last created CPU Worker. Necessary for the Stop menu item.
@@ -99,6 +99,7 @@ public class Main extends JApplet {
   private static List<JInternalFrame> ordered_frames;
 
   private static String openedFile = null;
+  public static String code = null;
   private static boolean debug_mode = false;
   private static JDesktopPane desk;
 
@@ -514,11 +515,11 @@ public class Main extends JApplet {
     dinero.reset();
 
     try {
-      // Aggiorniamo i componenti gai
+      // Update GUI components
       front.updateComponents();
       front.represent();
     } catch (Exception ex) {
-      new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), VERSION);
+      new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), VERSION, BUILD_DATE, GIT_REVISION, code);
     }
 
     try {
@@ -526,7 +527,7 @@ public class Main extends JApplet {
 
       try {
         String absoluteFilename = new File(file).getAbsolutePath();
-        parser.parse(absoluteFilename);
+        code = parser.parse(absoluteFilename);
       } catch (ParserMultiWarningException pmwe) {
         new ErrorDialog(mainFrame, pmwe.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean(ConfigKey.WARNINGS));
       } catch (NullPointerException e) {
@@ -544,7 +545,7 @@ public class Main extends JApplet {
       log.info("Set the status to RUNNING");
 
       // Let's fetch the first instruction
-      cpuWorker = new CPUSwingWorker(cpu, front, mainFrame, configStore, builder, VERSION, initCallback, haltCallback, finalizeCallback);
+      cpuWorker = new CPUSwingWorker(cpu, front, mainFrame, configStore, builder, initCallback, haltCallback, finalizeCallback);
       cpuWorker.setSteps(1);
       cpuWorker.execute();
       while (cpuWorker.isDone()) {
@@ -582,7 +583,7 @@ public class Main extends JApplet {
     } catch (Exception e) {
       mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
       log.info("Error opening " + file);
-      new ReportDialog(mainFrame, e, CurrentLocale.getString("ERROR"), VERSION);
+      new ReportDialog(mainFrame, e, CurrentLocale.getString("ERROR"), VERSION, BUILD_DATE, GIT_REVISION, code);
     }
   }
 
@@ -839,7 +840,7 @@ public class Main extends JApplet {
     // Lambda to create a CPUSwingWorker. Used to have a single place where CPUSwingWorker is
     // created.
     Supplier<CPUSwingWorker> workerBuilder = () ->
-        new CPUSwingWorker(cpu, front, mainFrame, configStore, builder, VERSION, initCallback, haltCallback, finalizeCallback);
+        new CPUSwingWorker(cpu, front, mainFrame, configStore, builder, initCallback, haltCallback, finalizeCallback);
 
     // ---------------- EXECUTE MENU
     // Execute a single simulation step

--- a/src/main/java/org/edumips64/Main.java
+++ b/src/main/java/org/edumips64/Main.java
@@ -55,11 +55,6 @@ import javax.swing.event.*;
 
 public class Main extends JApplet {
 
-  public static String VERSION;
-  public static String CODENAME;
-  public static String BUILD_DATE;
-  public static String GIT_REVISION;
-
   private static CPU cpu;
   // The last created CPU Worker. Necessary for the Stop menu item.
   private  static CPUSwingWorker cpuWorker;
@@ -117,7 +112,7 @@ public class Main extends JApplet {
   }
 
   private static void showVersion() {
-    System.out.println("EduMIPS64 version " + VERSION + " (codename: " + CODENAME + ", git revision " + GIT_REVISION + ", built on " + BUILD_DATE + ") - Ciao 'mbare.");
+    System.out.println("EduMIPS64 version " + MetaInfo.VERSION + " (codename: " + MetaInfo.CODENAME + ", git revision " + MetaInfo.GIT_REVISION + ", built on " + MetaInfo.BUILD_DATE + ") - Ciao 'mbare.");
   }
 
   // Parses the command-line arguments.
@@ -177,11 +172,6 @@ public class Main extends JApplet {
   }
 
   public static void main(String args[]) {
-    // Meta properties.
-    VERSION = MetaInfo.get("Signature-Version");
-    CODENAME = MetaInfo.get("Codename");
-    BUILD_DATE = MetaInfo.get("Build-Date");
-    GIT_REVISION = MetaInfo.get("Git-Revision");
 
     String toOpen = parseArgsOrExit(args);
 
@@ -208,7 +198,7 @@ public class Main extends JApplet {
     mainFrame.setLocation(0, 0);
     Main mm = new Main();
     mm.init();
-    mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
+    mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM"));
     mainFrame.setVisible(true);
     mainFrame.setExtendedState(mainFrame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
     // Auto-minimze the log window and the I/O window
@@ -303,7 +293,7 @@ public class Main extends JApplet {
     parser = new Parser(lfu, symTab, memory, instructionBuilder);
 
     builder = new CycleBuilder(cpu);
-    sb = new StatusBar(VERSION, configStore);
+    sb = new StatusBar(configStore);
     front = new GUIFrontend(cpu, memory, configStore, builder, sb);
 
     cpu.setCpuStatusChangeCallback(sb::setCpuStatusText);
@@ -519,7 +509,7 @@ public class Main extends JApplet {
       front.updateComponents();
       front.represent();
     } catch (Exception ex) {
-      new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), VERSION, BUILD_DATE, GIT_REVISION, code);
+      new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), MetaInfo.VERSION, MetaInfo.BUILD_DATE, MetaInfo.GIT_REVISION, code);
     }
 
     try {
@@ -561,12 +551,12 @@ public class Main extends JApplet {
         nome_file = token.nextToken();
       }
 
-      mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM") + " - " + nome_file);
+      mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM") + " - " + nome_file);
     } catch (ParserMultiException ex) {
       log.info("Error opening " + file);
       new ErrorDialog(mainFrame, ex.getExceptionList(), CurrentLocale.getString("GUI_PARSER_ERROR"), configStore.getBoolean(ConfigKey.WARNINGS));
       openedFile = null;
-      mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
+      mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM"));
       resetSimulator(false);
     } catch (ReadException ex) {
       String tmpfile;
@@ -577,13 +567,13 @@ public class Main extends JApplet {
         tmpfile = ex.getMessage();
       }
 
-      mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
+      mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM"));
       log.info("File not found: " + tmpfile);
       JOptionPane.showMessageDialog(mainFrame, CurrentLocale.getString("FILE_NOT_FOUND") + ": " + tmpfile, "EduMIPS64 - " + CurrentLocale.getString("ERROR"), JOptionPane.ERROR_MESSAGE);
     } catch (Exception e) {
-      mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
+      mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM"));
       log.info("Error opening " + file);
-      new ReportDialog(mainFrame, e, CurrentLocale.getString("ERROR"), VERSION, BUILD_DATE, GIT_REVISION, code);
+      new ReportDialog(mainFrame, e, CurrentLocale.getString("ERROR"), MetaInfo.VERSION, MetaInfo.BUILD_DATE, MetaInfo.GIT_REVISION, code);
     }
   }
 
@@ -655,9 +645,9 @@ public class Main extends JApplet {
   private static void setFrameTitles() {
     if (mainFrame != null) {
       if (openedFile != null) {
-        mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM") + " - " + openedFile);
+        mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM") + " - " + openedFile);
       } else {
-        mainFrame.setTitle("EduMIPS64 v. " + VERSION + " - " + CurrentLocale.getString("PROSIM"));
+        mainFrame.setTitle("EduMIPS64 v. " + MetaInfo.VERSION + " - " + CurrentLocale.getString("PROSIM"));
       }
     }
 
@@ -955,7 +945,7 @@ public class Main extends JApplet {
     aboutUs = new JMenuItem(CurrentLocale.getString("MenuItem.ABOUT_US"));
     help.add(aboutUs);
     aboutUs.addActionListener(e -> {
-      GUIAbout ab = new GUIAbout(null, VERSION, CODENAME, BUILD_DATE, GIT_REVISION);
+      GUIAbout ab = new GUIAbout(null, MetaInfo.VERSION, MetaInfo.CODENAME, MetaInfo.BUILD_DATE, MetaInfo.GIT_REVISION);
       //ab.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
       ab.setVisible(true);
     });

--- a/src/main/java/org/edumips64/MainCLI.java
+++ b/src/main/java/org/edumips64/MainCLI.java
@@ -179,12 +179,12 @@ public class MainCLI {
    * @return A string containing the error message.
    */
   private static String getErrorReportingMessage() {
-	  String msg = "EduMIPS64 fatal error!\n" +
-			  "Please report the following stacktrace and system information,\n" +
-			  "along with the content of the assembly file you were executing\n" +
-			  "to the EduMIPS64 GitHub account: https://github.com/lupino3/edumips64/issues/new\n";
-	  msg += String.format("Version: %s, %s, %s\n", Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION);
-      msg += String.format("JRE version: %s\nOS: %s\n\n", System.getProperty("java.version"), System.getProperty("os.name"));
-      return msg;
+    String msg = "EduMIPS64 fatal error!\n" +
+  		  "Please report the following stacktrace and system information,\n" +
+		  "along with the content of the assembly file you were executing\n" +
+		  "to the EduMIPS64 GitHub account: https://github.com/lupino3/edumips64/issues/new\n";
+    msg += String.format("Version: %s, %s, %s\n", Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION);
+    msg += String.format("JRE version: %s\nOS: %s\n\n", System.getProperty("java.version"), System.getProperty("os.name"));
+    return msg;
   }  
 }

--- a/src/main/java/org/edumips64/MainCLI.java
+++ b/src/main/java/org/edumips64/MainCLI.java
@@ -35,7 +35,6 @@ import java.io.*;
 /** Interactive shell for EduMIPS64
  * @author Andrea Spadaccini
  * */
-
 public class MainCLI {
   public static void main(String args[]) {
     try {
@@ -58,7 +57,7 @@ public class MainCLI {
       c.setStatus(CPU.CPUStatus.READY);
 
       // Initialization done. Print a welcome message and open the file if needed.
-      System.out.println("Benvenuto nella shell di EduMIPS64!!");
+      System.out.println("Welcome to EduMIPS64 CLI shell!");
       if (toOpen != null) {
         String absoluteFilename = new File(toOpen).getAbsolutePath();
         try {
@@ -70,7 +69,7 @@ public class MainCLI {
         }
         dinero.setDataOffset(memory.getInstructionsNumber()*4);
         c.setStatus(CPU.CPUStatus.RUNNING);
-        System.out.println("(Caricato il file " + absoluteFilename + ")");
+        System.out.println("(Loaded file " + absoluteFilename + ")");
       }
 
       // Start the (very primitive) Read/Eval/Print Loop.
@@ -87,26 +86,27 @@ public class MainCLI {
         String[] tokens = read.split(" ");
 
         if (tokens[0].compareToIgnoreCase("help") == 0) {
-          String help = "EduMIPS64 CLI SHELL - Comandi disponibili:\n";
+          String help = "EduMIPS64 CLI SHELL - Available commands:\n";
           help += "-----------------------------------------\n";
-          help += "help\t\t\tmostra questo messaggio di aiuto\n";
-          help += "step\t\t\tfa avanzare di uno step la macchina a stati della CPU:\n";
-          help += "step n\t\t\tfa avanzare di n step la macchina a stati della CPU:\n";
-          help += "run\t\t\tesegue il programma fino a terminazione\n";
-          help += "show registers\t\tmostra il contenuto dei registri\n";
-          help += "show memory\t\tmostra il contenuto della memoria\n";
-          help += "show symbols\t\tmostra il contenuto della symbol table\n";
-          help += "show pipeline\t\tmostra il contenuto della pipeline\n";
+          help += "help\t\t\tshow this help message\n";
+          help += "step\t\t\tmake the CPU state machine advance of one step\n";
+          help += "step n\t\t\tmake the CPU state machine advance of n steps\n";
+          help += "run\t\t\texecute the program till its end\n";
+          help += "show registers\t\tshow the content of registries\n";
+          help += "show memory\t\tshow the content of memory\n";
+          help += "show symbols\t\tshow the content of the symbol table\n";
+          help += "show pipeline\t\tshow the content of the pipeline\n";
+          help += "exit\t\t\texit EduMIPS64 CLI shell\n";
           System.out.println(help);
         } else if (tokens[0].compareToIgnoreCase("show") == 0) {
           if (tokens.length == 1) {
-            System.out.println("Bisogna fornire almeno un parametro al comando show");
+            System.out.println("The show command requires at least one parameter.");
           } else {
             if (tokens[1].compareToIgnoreCase("registers") == 0) {
               System.out.println(c.gprString());
             } else if (tokens[1].compareToIgnoreCase("register") == 0) {
               if (tokens.length < 3) {
-                System.out.println("Bisogna fornire almeno un parametro al comando show register");
+                System.out.println("The show register command requires at least one parameter.");
               } else {
                 System.out.println(c.getRegister(Integer.parseInt(tokens[2])));
               }
@@ -117,7 +117,7 @@ public class MainCLI {
             } else if (tokens[1].compareToIgnoreCase("pipeline") == 0) {
               System.out.println(c.pipeLineString());
             } else {
-              System.out.println("Bisogna fornire almeno un parametro al comando show");
+              System.out.println("The show command requires at least one parameter.");
             }
           }
         } else if (tokens[0].compareTo("run") == 0) {
@@ -132,7 +132,7 @@ public class MainCLI {
             } catch (HaltException e) {
               long endTimeMs = System.currentTimeMillis();
               long totalTimeMs = endTimeMs - startTimeMs;
-              System.out.println("Esecuzione terminata. " + steps + " step eseguiti in " + totalTimeMs + "ms");
+              System.out.println("Execution ended. " + steps + " steps were executed in " + totalTimeMs + "ms");
             }
         } else if (tokens[0].compareTo("step") == 0) {
           try {
@@ -144,7 +144,7 @@ public class MainCLI {
 
             try {
               if (num > 0) {
-                System.out.println("Eseguo " + num + " step di simulazione");
+                System.out.println("I execute " + num + " steps of simulation.");
               }
 
               for (int i = 0; i < num; ++i) {
@@ -152,23 +152,39 @@ public class MainCLI {
                 System.out.println(c.pipeLineString());
               }
             } catch (Exception e) {
-              System.out.println("Eccezione durante lo step!!");
+              System.err.println(getErrorReportingMessage());
               e.printStackTrace();
             }
           } catch (NumberFormatException e) {
-            System.out.println("Il secondo parametro del comando step dev'essere un numero intero");
+            System.out.println("The second parameter of the step command must be an integer.");
           }
         } else {
-          System.out.println("Comando non riconosciuto.\nDigitare 'help' per avere un elenco di comandi");
+          System.out.println("Unknown command.\nType 'help' to get the list of available commands.");
         }
 
         System.out.print("> ");
       }
 
-      System.out.println("Ciao ciao!");
+      System.out.println("Bye!");
     } catch (Exception e) {
+      System.err.println(getErrorReportingMessage());
       e.printStackTrace();
       System.exit(1);
     }
   }
+  
+  /**
+   * Compiles and returns a generic error message with version 
+   * and system diagnostic information to be used to report the error.
+   * @return A string containing the error message.
+   */
+  private static String getErrorReportingMessage() {
+	  String msg = "EduMIPS64 fatal error!\n" +
+			  "Please report the following stacktrace and system information,\n" +
+			  "along with the content of the assembly file you were executing\n" +
+			  "to the EduMIPS64 GitHub account: https://github.com/lupino3/edumips64/issues/new\n";
+	  msg += String.format("Version: %s, %s, %s\n", Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION);
+      msg += String.format("JRE version: %s\nOS: %s\n\n", System.getProperty("java.version"), System.getProperty("os.name"));
+      return msg;
+  }  
 }

--- a/src/main/java/org/edumips64/MainCLI.java
+++ b/src/main/java/org/edumips64/MainCLI.java
@@ -180,10 +180,10 @@ public class MainCLI {
    */
   private static String getErrorReportingMessage() {
     String msg = "EduMIPS64 fatal error!\n" +
-  		  "Please report the following stacktrace and system information,\n" +
-		  "along with the content of the assembly file you were executing\n" +
-		  "to the EduMIPS64 GitHub account: https://github.com/lupino3/edumips64/issues/new\n";
-    msg += String.format("Version: %s, %s, %s\n", Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION);
+        "Please report the following stacktrace and system information,\n" +
+        "along with the content of the assembly file you were executing\n" +
+        "to the EduMIPS64 GitHub account: https://github.com/lupino3/edumips64/issues/new\n";
+    msg += String.format("Version: %s, %s, %s\n", MetaInfo.VERSION, MetaInfo.BUILD_DATE, MetaInfo.GIT_REVISION);
     msg += String.format("JRE version: %s\nOS: %s\n\n", System.getProperty("java.version"), System.getProperty("os.name"));
     return msg;
   }  

--- a/src/main/java/org/edumips64/core/parser/Parser.java
+++ b/src/main/java/org/edumips64/core/parser/Parser.java
@@ -108,14 +108,16 @@ public class Parser {
   /** Loading from File
    * @param filename A String with the system-dependent file name. It should be an absolute file name.
    * @throws SecurityException if a security manager exists and its checkRead method denies read access to the file.
+   * @returns A string containing the code parsed.
    */
-  public void parse(String filename) throws ParserMultiException, ReadException {
+  public String parse(String filename) throws ParserMultiException, ReadException {
     logger.info("About to parse " + filename);
     this.filename = filename;
     basePath = fileUtils.GetBasePath(filename);
     String code = preprocessor(filename);
     doParsing(code);
     logger.info(filename + " correctly parsed.");
+    return code;
   }
 
   /** Replace all Tabulator with space

--- a/src/main/java/org/edumips64/ui/swing/CPUSwingWorker.java
+++ b/src/main/java/org/edumips64/ui/swing/CPUSwingWorker.java
@@ -196,7 +196,7 @@ public class CPUSwingWorker extends SwingWorker<Void, Void> {
         break;
       } catch (Exception ex) {
         logger.severe("Exception in CPUSwingWorker: " + ex);
-        SwingUtilities.invokeLater(() -> new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION, Main.code));
+        SwingUtilities.invokeLater(() -> new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), MetaInfo.VERSION, MetaInfo.BUILD_DATE, MetaInfo.GIT_REVISION, Main.code));
         haltCPU();
         break;
       } finally {

--- a/src/main/java/org/edumips64/ui/swing/CPUSwingWorker.java
+++ b/src/main/java/org/edumips64/ui/swing/CPUSwingWorker.java
@@ -70,19 +70,17 @@ public class CPUSwingWorker extends SwingWorker<Void, Void> {
   private CycleBuilder builder;
 
   private static final Logger logger = Logger.getLogger(CPUSwingWorker.class.getName());
-  private String version;
 
   /** Callbacks */
   private Runnable initCallback, haltCallback, finalizeCallback;
 
-  public CPUSwingWorker(CPU cpu, GUIFrontend front, JFrame mainFrame, ConfigStore config, CycleBuilder builder, String version, Runnable initCallback, Runnable haltCallback, Runnable finalizeCallback) {
+  public CPUSwingWorker(CPU cpu, GUIFrontend front, JFrame mainFrame, ConfigStore config, CycleBuilder builder, Runnable initCallback, Runnable haltCallback, Runnable finalizeCallback) {
     externalStop = false;
     this.builder = builder;
     this.cpu = cpu;
     this.front = front;
     this.mainFrame = mainFrame;
     this.config = config;
-    this.version = version;
     updateConfigValues();
 
     this.haltCallback = haltCallback;
@@ -198,7 +196,7 @@ public class CPUSwingWorker extends SwingWorker<Void, Void> {
         break;
       } catch (Exception ex) {
         logger.severe("Exception in CPUSwingWorker: " + ex);
-        SwingUtilities.invokeLater(() -> new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), version));
+        SwingUtilities.invokeLater(() -> new ReportDialog(mainFrame, ex, CurrentLocale.getString("GUI_STEP_ERROR"), Main.VERSION, Main.BUILD_DATE, Main.GIT_REVISION, Main.code));
         haltCPU();
         break;
       } finally {

--- a/src/main/java/org/edumips64/ui/swing/ReportDialog.java
+++ b/src/main/java/org/edumips64/ui/swing/ReportDialog.java
@@ -125,13 +125,13 @@ public class ReportDialog extends JDialog implements HyperlinkListener {
   }
 
   public void hyperlinkUpdate(HyperlinkEvent hle) {
-	if (HyperlinkEvent.EventType.ACTIVATED.equals(hle.getEventType())) {
-		Desktop desktop = Desktop.getDesktop();
-		try {
-			desktop.browse(hle.getURL().toURI());
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-	}	
+    if (HyperlinkEvent.EventType.ACTIVATED.equals(hle.getEventType())) {
+      Desktop desktop = Desktop.getDesktop();
+      try {
+        desktop.browse(hle.getURL().toURI());
+      } catch (Exception ex) {
+        ex.printStackTrace();
+      }
+    }
   }
 }

--- a/src/main/java/org/edumips64/ui/swing/StatusBar.java
+++ b/src/main/java/org/edumips64/ui/swing/StatusBar.java
@@ -26,6 +26,7 @@ package org.edumips64.ui.swing;
 import org.edumips64.utils.ConfigKey;
 import org.edumips64.utils.ConfigStore;
 import org.edumips64.utils.CurrentLocale;
+import org.edumips64.utils.MetaInfo;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -44,10 +45,10 @@ public class StatusBar {
   private JProgressBar pb;
   private Component sbComponent;
 
-  public StatusBar(String version, ConfigStore cfg) {
+  public StatusBar(ConfigStore cfg) {
     statusLabel = new JLabel();
     statusLabel.setFont(statusLabel.getFont().deriveFont((float)cfg.getInt(ConfigKey.UI_FONT_SIZE)));
-    statusLabel.setText(CurrentLocale.getString("StatusBar.WELCOME") + " " + version);
+    statusLabel.setText(CurrentLocale.getString("StatusBar.WELCOME") + " " + MetaInfo.VERSION);
 
     cpuStatusLabel = new JLabel();
     cpuStatusLabel.setFont(statusLabel.getFont().deriveFont((float)cfg.getInt(ConfigKey.UI_FONT_SIZE)));

--- a/src/main/java/org/edumips64/utils/CurrentLocale.java
+++ b/src/main/java/org/edumips64/utils/CurrentLocale.java
@@ -218,7 +218,8 @@ public class CurrentLocale {
     en.put("ErrorDialog.MSG0", "Code contains");
     en.put("ErrorDialog.MSG1", "errors and");
     en.put("ErrorDialog.MSG2", String.valueOf(ConfigKey.WARNINGS));
-    en.put("ReportDialog.MSG", "EduMIPS64 Fatal error! Please help the developers, by opening a new issue on GitHub (https://github.com/lupino3/edumips64/issues/new) with the following text, or by sending it via email to bugs@edumips.org");
+    en.put("ReportDialog.MSG", "EduMIPS64 Fatal error!<br/>Please help the developers, by opening a <a href='https://github.com/lupino3/edumips64/issues/new'>new issue on GitHub</a> with the following text, "
+    		+ "or by sending it via email to <a href='mailto:bugs@edumips.org'>bugs@edumips.org</a>.");
     en.put("ReportDialog.BUTTON", "Close");
     en.put("DIVZERO.Message", "Division by zero");
     en.put("INTOVERFLOW.Message", "Integer overflow");
@@ -436,7 +437,8 @@ public class CurrentLocale {
     it.put("ErrorDialog.MSG0", "Il codice contiene");
     it.put("ErrorDialog.MSG1", "errori e");
     it.put("ErrorDialog.MSG2", "avvisi");
-    it.put("ReportDialog.MSG", "Errore fatale! Aiuta gli sviluppatori, aprendo una issue su GitHub(https://github.com/lupino3/edumips64/issues/new) con il seguente testo, o inviandolo via email a bugs@edumips.org");
+    it.put("ReportDialog.MSG", "Errore fatale!<br/>Aiuta gli sviluppatori, aprendo una <a href='https://github.com/lupino3/edumips64/issues/new'>issue su GitHub</a> con il seguente testo, "
+    		+ "o inviandolo via email a <a href='mailto:bugs@edumips.org'>bugs@edumips.org</a>.");
     it.put("ReportDialog.BUTTON", "Chiudi");
     it.put("DIVZERO.Message", "Divisione per zero");
     it.put("INTOVERFLOW.Message", "Integer overflow");

--- a/src/main/java/org/edumips64/utils/MetaInfo.java
+++ b/src/main/java/org/edumips64/utils/MetaInfo.java
@@ -21,6 +21,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 package org.edumips64.utils;
+
 import java.net.URLDecoder;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -30,27 +31,33 @@ import java.util.jar.Manifest;
 public class MetaInfo {
   static Attributes attributes;
 
+  public static String VERSION;
+  public static String CODENAME;
+  public static String BUILD_DATE;
+  public static String GIT_REVISION;
+
   static {
     try {
-      String path = MetaInfo.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-      String decodedPath = URLDecoder.decode(path, "UTF-8");
-      JarFile myJar = new JarFile(decodedPath);
-      Manifest manifest = myJar.getManifest();
-      if (manifest != null) {
-        attributes = manifest.getMainAttributes();
-      } else {
-        System.err.println("Error while getting the manifest from the JAR file.");
+      JarFile myJar = null;
+      try {
+        String path = MetaInfo.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        String decodedPath = URLDecoder.decode(path, "UTF-8");
+        myJar = new JarFile(decodedPath);
+        Manifest manifest = myJar.getManifest();
+        if (manifest != null) {
+          attributes = manifest.getMainAttributes();
+          VERSION = attributes.getValue("Signature-Version");
+          CODENAME = attributes.getValue("Codename");
+          BUILD_DATE = attributes.getValue("Build-Date");
+          GIT_REVISION = attributes.getValue("Git-Revision");
+        } else
+          System.err.println("Error while getting the manifest from the JAR file.");
+      } finally {
+        if (myJar != null)
+          myJar.close();
       }
     } catch (Exception e) {
       System.err.println("Error while fetching version info from the jar file.");
     }
-  }
-
-  // Returns the attribute value, or an empty string if it isn't found.
-  public static String get(String attribute) {
-    if (attributes == null) {
-      return "";
-    }
-    return attributes.getValue(attribute);
   }
 }


### PR DESCRIPTION
 - [x] adds hyperlinks to GitHub URL and email for reporting the error
 - [x] adds full code of the loaded assembly file, git version, build date
 - [x] adds Markdown formatting to the text to be reported
 - [x] adds similar diagnostic text to CLI exception handling 

The resulting dialog looks like this:
![image](https://user-images.githubusercontent.com/1350095/72671390-587b9200-3a41-11ea-93a4-1ae52f0787a4.png)

Note: 
 - I modified the parser to return the full code, and created a variable in Main to store it
 - I removed the "version" function parameter and attribute of CPUSwingWorker and have it use the attribute of Main instead, since it's an attribute of the application as a whole after all

**Edit**:
 - added the CLI error message reporting
 - translated to English all CLI console output
 - ~~NB: at the moment Main.VERSION etc are not populated when executing the CLI shell - they'd have to be extracted from Main I guess~~

(The ErrorDialog class has not be considered for this - should it be?)

Close #256 
Close #261 